### PR TITLE
Proposal: drop numpy dependency (simpler, faster code).

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ install:
     - git clone https://github.com/RoaringBitmap/CRoaring.git
     - cd CRoaring && mkdir -p build && cd build && cmake .. && make && cd ../..
     - export LD_LIBRARY_PATH=CRoaring/build:$LD_LIBRARY_PATH
-    - pip install hypothesis numpy
+    - pip install hypothesis 
 
 script:
   - python test.py

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ It provides a very efficient way to store and manipulate sets of (unsigned 32 bi
 ## Requirements
 
 - Python 3.3 or better
-- Numpy
+- Numpy (optional, for benchmarking)
 - The Python package ``hypothesis`` (optional, for testing)
 
 ## Installation
@@ -57,7 +57,5 @@ bm2       = BitMap([3, 27, 42])
 bm1 & bm2 = BitMap([3])
 bm1 | bm2 = BitMap([3, 18, 27, 42])
 ```
+Warning: when creating a new `BitMap` instance from a Python `list`, we truncate all integers to the least significant bits (values between 0 and 2^32).
 
-Warning: the creation of a new `BitMap` instance from a Python `list` is quite slow. This is mainly due to the verification of the data consistency (i.e. checking that we have integers between 0 and 2^32-1) and the conversion from the Python data structure to a C array. We should find a way to improve that in a near future.
-
-Creating a `BitMap` from a `range` object is much more efficient (e.g. `bm = BitMap(range(2**30))`), since the verifications only have to be done on the bounds of the range.

--- a/pyroaring.py
+++ b/pyroaring.py
@@ -1,5 +1,4 @@
 import sys
-import numpy
 from types_declarations import *
 
 is_python2 = sys.version_info < (3, 0)
@@ -17,6 +16,7 @@ def dump(fp, bitmap):
 class BitMap:
 
     def __init__(self, values=None, obj=None):
+        """ Construct a BitMap object. If a list of integers is provided, the integers are truncated down to the least significant 32 bits"""
         if obj is not None:
             self.__obj__ = obj
             return
@@ -44,13 +44,8 @@ class BitMap:
         else:
             if not isinstance(values, list):
                 values = list(values)
-            c_array = numpy.ascontiguousarray(values, dtype=numpy.int64)
-            wrong_values = (c_array < 0) | (c_array >= 2**32)
-            if wrong_values.any():
-                raise ValueError('Following values are not an uint32:\n %s' % list(c_array[wrong_values]))
             size = len(values)
-            c_array = c_array.astype(ctypes.c_uint32)
-            values = c_array.ctypes.data_as(ctypes.POINTER(val_type))
+            values = (ctypes.c_uint32 * size)(*values)
             self.__obj__ = libroaring.roaring_bitmap_of_ptr(size, values)
             libroaring.roaring_bitmap_run_optimize(self.__obj__)
 

--- a/pyroaring.py
+++ b/pyroaring.py
@@ -16,12 +16,8 @@ def dump(fp, bitmap):
 class BitMap:
 
     def __init__(self, values=None, obj=None):
-<<<<<<< HEAD
         """ Construct a BitMap object. If a list of integers is provided, the integers are truncated down to the least significant 32 bits"""
-        if obj is not None:
-=======
         if obj is not None and values is None:
->>>>>>> upstream/master
             self.__obj__ = obj
             return
         if values is None:

--- a/test.py
+++ b/test.py
@@ -137,12 +137,6 @@ class BasicTest(Util):
         self.wrong_op(lambda bitmap, value: bitmap.__contains__(value))
 
     def test_wrong_constructor_values(self):
-        # It seems perfectly fine to truncate values to first 32 bits
-        #with self.assertRaises(ValueError):
-        #    bitmap = BitMap([3, 1, -3, 42])
-        #with self.assertRaises(ValueError):
-        #    bitmap = BitMap([3, 2**100, 3, 42])
-        #
         with self.assertRaises(TypeError): # this should fire a type error!
             bitmap = BitMap([3, 'bla', 3, 42])
         with self.assertRaises(ValueError):

--- a/test.py
+++ b/test.py
@@ -137,11 +137,13 @@ class BasicTest(Util):
         self.wrong_op(lambda bitmap, value: bitmap.__contains__(value))
 
     def test_wrong_constructor_values(self):
-        with self.assertRaises(ValueError):
-            bitmap = BitMap([3, 1, -3, 42])
-        with self.assertRaises(ValueError):
-            bitmap = BitMap([3, 2**33, 3, 42])
-        with self.assertRaises(ValueError):
+        # It seems perfectly fine to truncate values to first 32 bits
+        #with self.assertRaises(ValueError):
+        #    bitmap = BitMap([3, 1, -3, 42])
+        #with self.assertRaises(ValueError):
+        #    bitmap = BitMap([3, 2**100, 3, 42])
+        #
+        with self.assertRaises(TypeError): # this should fire a type error!
             bitmap = BitMap([3, 'bla', 3, 42])
         with self.assertRaises(ValueError):
             bitmap = BitMap(range(0, 10, 0))


### PR DESCRIPTION
The current code relies on ``numpy`` for one tiny operation that seems unwarranted. On my machine, it is about half the speed of a good old ``ctype`` array. 

I propose to simplify the code to remove a nagging dependency and to improve the performance.

Of course, ``numpy`` is pretty good at checking that integers are in a given range, but it is not perfect. If, for some reason, an integer cannot be converted to a machine word, we get an ugly ``OverflowError``.


```python
>>> values = [1<<100]
>>> c_array = numpy.ascontiguousarray(values, dtype=numpy.int64)
Traceback (most recent call last):
"/System/Library/Frameworks/Python.framework/Versions/2.7/Extras/lib/python/numpy/core/numeric.py", line 548, in ascontiguousarray
    return array(a, dtype, copy=False, order='C', ndmin=1)
OverflowError: Python int too large to convert to C long
```


With a standard Python array, you can just cast on the least significant 32 bits. That's perfectly "safe" and predictable. What if the programmer tries to use values above 32 bit? Some of its vallues will get casted... but that's not different from, say, ``numpy``'s default behavior:

```python
>>> numpy.ascontiguousarray([1<<34],dtype=numpy.uint32)
array([0], dtype=uint32)
```
That's going to work just fine, outputting a zero. I don't think that this is a bug-prone behavior. It is just a cast.

Now, if you must, you can easily provide a convenience function allowing the user to check whether its values are "safe" 32-bit integers.

One last note... I did not check it, but I think that your ``check_value`` function can be simplified to be something like ``(x >> 32) == 0``. I suspect it is going to be faster. (I don't think there is any need of checking the type.)


