### PR TITLE
API-compatibility with python sets.

### DIFF
--- a/pyroaring/abstract_bitmap.pxi
+++ b/pyroaring/abstract_bitmap.pxi
@@ -212,24 +212,54 @@ cdef class AbstractBitMap:
     def copy(self):
         """
         Return a copy of a set.
+
+        >>> bm = BitMap([3, 12])
+        >>> bm2 = bm.copy()
+        >>> bm == bm2
+        True
+        >>> bm.add(1)
+        >>> bm == bm2
+        False
+
         """
         return self.__class__(self)
 
     def isdisjoint(self, other):
         """
         Return True if two sets have a null intersection.
+
+        >>> BitMap([1, 2]).isdisjoint(BitMap([3, 4]))
+        True
+
+        >>> BitMap([1, 2, 3]).isdisjoint(BitMap([3, 4]))
+        False
+
         """
         return self.intersection_cardinality(other) == 0
 
     def issubset(self, other):
         """
         Report whether another set contains this set.
+
+        >>> BitMap([1, 2]).issubset(BitMap([1, 2, 3, 4]))
+        True
+
+        >>> BitMap([1, 2]).issubset(BitMap([3, 4]))
+        False
+
         """
         return self <= other
 
     def issuperset(self, other):
         """
         Report whether this set contains another set.
+
+        >>> BitMap([1, 2, 3, 4]).issuperset(BitMap([1, 2]))
+        True
+
+        >>> BitMap([1, 2]).issuperset(BitMap([3, 4]))
+        False
+
         """
         return self >= other
 
@@ -238,6 +268,10 @@ cdef class AbstractBitMap:
         Return the difference of two or more sets as a new set.
 
         (i.e. all elements that are in this set but not the others.)
+
+        >>> BitMap.difference(BitMap([1, 2, 3]), BitMap([2, 20]), BitMap([3, 30]))
+        BitMap([1])
+
         """
         difference = BitMap(self)
         for other in others:
@@ -253,6 +287,9 @@ cdef class AbstractBitMap:
         Return the symmetric difference of two sets as a new set.
 
         (i.e. all elements that are in exactly one of the sets.)
+
+        >>> BitMap([1, 2, 3]).symmetric_difference(BitMap([2, 3, 4]))
+        BitMap([1, 4])
         """
         return self.__xor__(other)
 

--- a/pyroaring/abstract_bitmap.pxi
+++ b/pyroaring/abstract_bitmap.pxi
@@ -219,19 +219,19 @@ cdef class AbstractBitMap:
         """
         Return True if two sets have a null intersection.
         """
-        return AbstractBitMap.intersection_cardinality(self, other) == 0
+        return self.intersection_cardinality(other) == 0
 
     def issubset(self, other):
         """
         Report whether another set contains this set.
         """
-        return AbstractBitMap.intersection_cardinality(self, other) == len(self)
+        return self <= other
 
     def issuperset(self, other):
         """
         Report whether this set contains another set.
         """
-        return AbstractBitMap.intersection_cardinality(self, other) == len(other)
+        return self >= other
 
     def difference(self, *others):
         """
@@ -241,7 +241,7 @@ cdef class AbstractBitMap:
         """
         difference = BitMap(self)
         for other in others:
-            difference.__ixor__(difference & other)
+            difference.__isub__(other)
 
         if not isinstance(self, BitMap):
             return self.__class__(difference)
@@ -254,10 +254,7 @@ cdef class AbstractBitMap:
 
         (i.e. all elements that are in exactly one of the sets.)
         """
-        return AbstractBitMap.difference(
-            AbstractBitMap.union(self, other),
-            AbstractBitMap.intersection(self, other)
-        )
+        return self.__xor__(other)
 
     def union(self, *others):
         """

--- a/pyroaring/abstract_bitmap.pxi
+++ b/pyroaring/abstract_bitmap.pxi
@@ -213,7 +213,7 @@ cdef class AbstractBitMap:
         """
         Return a copy of a set.
         """
-        return self.__class__(self, copy_on_write=self._c_bitmap.copy_on_write)
+        return self.__class__(self)
 
     def isdisjoint(self, other):
         """

--- a/pyroaring/abstract_bitmap.pxi
+++ b/pyroaring/abstract_bitmap.pxi
@@ -276,9 +276,9 @@ cdef class AbstractBitMap:
         size = len(bitmaps)
         cdef AbstractBitMap result, bm
         if size <= 1:
-            return bitmaps[0].__class__(*bitmaps)
+            return bitmaps[0].copy()
         elif size == 2:
-            return (<AbstractBitMap>bitmaps[0]).binary_op(<AbstractBitMap?>bitmaps[1], croaring.roaring_bitmap_andnot)
+            return bitmaps[0] - bitmaps[1]
         else:
             result = BitMap(bitmaps[0])
             for bm in bitmaps[1:]:
@@ -309,9 +309,9 @@ cdef class AbstractBitMap:
         cdef AbstractBitMap bm
         cdef vector[const croaring.roaring_bitmap_t*] buff
         if size <= 1:
-            return bitmaps[0].__class__(*bitmaps)
+            return bitmaps[0].copy()
         elif size == 2:
-            return (<AbstractBitMap>bitmaps[0]).binary_op(<AbstractBitMap?>bitmaps[1], croaring.roaring_bitmap_or)
+            return bitmaps[0] | bitmaps[1]
         else:
             for bm in bitmaps:
                 bitmaps[0].__check_compatibility(bm)
@@ -329,9 +329,9 @@ cdef class AbstractBitMap:
         size = len(bitmaps)
         cdef AbstractBitMap result, bm
         if size <= 1:
-            return bitmaps[0].__class__(*bitmaps)
+            return bitmaps[0].copy()
         elif size == 2:
-            return (<AbstractBitMap>bitmaps[0]).binary_op(<AbstractBitMap?>bitmaps[1], croaring.roaring_bitmap_and)
+            return bitmaps[0] & bitmaps[1]
         else:
             result = BitMap(bitmaps[0])
             for bm in bitmaps[1:]:

--- a/pyroaring/bitmap.pxi
+++ b/pyroaring/bitmap.pxi
@@ -137,7 +137,7 @@ cdef class BitMap(AbstractBitMap):
         BitMap([3, 4, 10])
 
         """
-        union = self.__ixor__(other)
+        self.__ixor__(other)
 
     def clear(self):
         """

--- a/pyroaring/bitmap.pxi
+++ b/pyroaring/bitmap.pxi
@@ -119,23 +119,52 @@ cdef class BitMap(AbstractBitMap):
     def difference_update(self, *others):
         """
         Remove all elements of another set from this set.
+
+        >>> bm = BitMap([1, 2, 3, 4, 5])
+        >>> bm.difference_update(BitMap([1, 2, 10]), BitMap([3, 4, 20]))
+        >>> bm
+        BitMap([5])
         """
         self.__isub__(AbstractBitMap.union(*others))
 
     def symmetric_difference_update(self, other):
         """
         Update a set with the symmetric difference of itself and another.
+
+        >>> bm = BitMap([1, 2, 3, 4])
+        >>> bm.symmetric_difference_update(BitMap([1, 2, 10]))
+        >>> bm
+        BitMap([3, 4, 10])
+
         """
         union = self.__ixor__(other)
 
     def clear(self):
-        """Remove all elements from this set."""
+        """
+        Remove all elements from this set.
+
+        >>> bm = BitMap([1, 2, 3])
+        >>> bm.clear()
+        >>> bm
+        BitMap([])
+        """
         croaring.roaring_bitmap_clear(self._c_bitmap)
 
     def pop(self):
         """
         Remove and return an arbitrary set element.
         Raises KeyError if the set is empty.
+
+        >>> bm = BitMap([1, 2])
+        >>> a = bm.pop()
+        >>> b = bm.pop()
+        >>> bm
+        BitMap([])
+        >>> bm.pop()
+        Traceback (most recent call last):
+        ...
+        KeyError: 'pop from an empty BitMap'
+
         """
         try:
             value = self.min()

--- a/pyroaring/bitmap.pxi
+++ b/pyroaring/bitmap.pxi
@@ -132,7 +132,7 @@ cdef class BitMap(AbstractBitMap):
 
     def clear(self):
         """Remove all elements from this set."""
-        self.__isub__(self)
+        croaring.roaring_bitmap_clear(self._c_bitmap)
 
     def pop(self):
         """

--- a/pyroaring/bitmap.pxi
+++ b/pyroaring/bitmap.pxi
@@ -126,9 +126,7 @@ cdef class BitMap(AbstractBitMap):
         """
         Update a set with the symmetric difference of itself and another.
         """
-        union = self & other
-        self.__ior__(other)
-        self.__isub__(union)
+        union = self.__ixor__(other)
 
     def clear(self):
         """Remove all elements from this set."""

--- a/pyroaring/bitmap.pxi
+++ b/pyroaring/bitmap.pxi
@@ -116,6 +116,37 @@ cdef class BitMap(AbstractBitMap):
             else:
                 self &= AbstractBitMap(values, copy_on_write=self.copy_on_write)
 
+    def difference_update(self, *others):
+        """
+        Remove all elements of another set from this set.
+        """
+        self.__isub__(AbstractBitMap.union(*others))
+
+    def symmetric_difference_update(self, other):
+        """
+        Update a set with the symmetric difference of itself and another.
+        """
+        union = self & other
+        self.__ior__(other)
+        self.__isub__(union)
+
+    def clear(self):
+        """Remove all elements from this set."""
+        self.__isub__(self)
+
+    def pop(self):
+        """
+        Remove and return an arbitrary set element.
+        Raises KeyError if the set is empty.
+        """
+        try:
+            value = self.min()
+        except ValueError:
+            raise KeyError('pop from an empty BitMap')
+        self.remove(value)
+        return value
+
+
     def flip_inplace(self, uint64_t start, uint64_t end):
         """
         Compute (in place) the negation of the bitmap within the specified interval.

--- a/pyroaring/croaring.pxd
+++ b/pyroaring/croaring.pxd
@@ -42,6 +42,7 @@ cdef extern from "roaring.h":
     void roaring_bitmap_remove(roaring_bitmap_t *r, uint32_t x)
     inline void roaring_bitmap_remove_range(roaring_bitmap_t *ra, uint64_t min, uint64_t max)
     bool roaring_bitmap_remove_checked(roaring_bitmap_t *r, uint32_t x)
+    void roaring_bitmap_clear(roaring_bitmap_t *r)
     bool roaring_bitmap_contains(const roaring_bitmap_t *r, uint32_t val)
     bool roaring_bitmap_contains_range(const roaring_bitmap_t *r, uint64_t range_start, uint64_t range_end)
     roaring_bitmap_t *roaring_bitmap_copy(const roaring_bitmap_t *r)

--- a/test.py
+++ b/test.py
@@ -882,7 +882,16 @@ class PythonSetEquivalentTest(unittest.TestCase):
 
         converted_set = SetClass(b1)
 
-        min_value, max_value = min(s1, default=0), max(s1, default=200) + 1
+        try:
+            min_value = min(s1)
+        except ValueError:
+            min_value = 0
+
+        try:
+            max_value = max(s1) + 1
+        except ValueError:
+            max_value = 200 + 1
+
         for i in range(min_value, max_value):
             self.assertEqual(i in s1, i in converted_set)
 
@@ -1030,7 +1039,11 @@ class PythonSetEquivalentTest(unittest.TestCase):
         b1 = BitMap(list1)
         b2 = b1.copy()
 
-        new_element = max(b1, default = 0) + 1 #doesn't exist in the set
+        try:
+            new_element = max(b1) + 1 #doesn't exist in the set
+        except ValueError:
+            new_element = 1
+
         b2.add(new_element)
 
         self.assertTrue(new_element in b2)

--- a/test.py
+++ b/test.py
@@ -522,6 +522,7 @@ class ManyOperationsTest(Util):
         self.assertEqual(expected_result, self.initial_bitmap)
         self.assertEqual(type(expected_result), type(self.initial_bitmap))
 
+    @unittest.skipIf(is_python2, 'https://github.com/Ezibenroc/PyRoaringBitMap/pull/38#issuecomment-418262391')
     @given(bitmap_cls, st.data(), hyp_many_collections, st.booleans())
     def test_union(self, cls, data, all_values, cow):
         classes = [data.draw(bitmap_cls) for _ in range(len(all_values))]
@@ -532,6 +533,7 @@ class ManyOperationsTest(Util):
             lambda x, y: x | y, self.all_bitmaps)
         self.assertEqual(expected_result, result)
 
+    @unittest.skipIf(is_python2, 'https://github.com/Ezibenroc/PyRoaringBitMap/pull/38#issuecomment-418262391')
     @given(bitmap_cls, st.data(), hyp_many_collections, st.booleans())
     def test_intersection(self, cls, data, all_values, cow):
         classes = [data.draw(bitmap_cls) for _ in range(len(all_values))]

--- a/test.py
+++ b/test.py
@@ -544,6 +544,17 @@ class ManyOperationsTest(Util):
             lambda x, y: x & y, self.all_bitmaps)
         self.assertEqual(expected_result, result)
 
+    @unittest.skipIf(is_python2, 'https://github.com/Ezibenroc/PyRoaringBitMap/pull/38#issuecomment-418262391')
+    @given(bitmap_cls, st.data(), hyp_many_collections, st.booleans())
+    def test_difference(self, cls, data, all_values, cow):
+        classes = [data.draw(bitmap_cls) for _ in range(len(all_values))]
+        self.all_bitmaps = [classes[i](values, copy_on_write=cow)
+                            for i, values in enumerate(all_values)]
+        result = cls.difference(*self.all_bitmaps)
+        expected_result = functools.reduce(
+            lambda x, y: x - y, self.all_bitmaps)
+        self.assertEqual(expected_result, result)
+
 
 class SerializationTest(Util):
 

--- a/test.py
+++ b/test.py
@@ -972,6 +972,65 @@ class PythonSetEquivalentTest(unittest.TestCase):
         self.assertEqual(s1.issubset(s2), b1.issubset(b2))
         self.assertEqual(SetClass.issubset(s1, s2), BitMapClass.issubset(b1, b2))
 
+
+    @given(bitmap_cls, small_integer_list, small_integer_list)
+    def test_le(self, BitMapClass, list1, list2):
+        if BitMapClass == BitMap:
+            SetClass = set
+        elif BitMapClass == FrozenBitMap:
+            SetClass = frozenset
+        else:
+            raise AssertionError()
+
+        s1 = SetClass(list1)
+        s2 = SetClass(list2)
+
+        b1 = BitMapClass(list1)
+        b2 = BitMapClass(list2)
+
+        self.assertEqual(s1.__le__(s2), b1.__le__(b2))
+        self.assertEqual(SetClass.__le__(s1, s2), BitMapClass.__le__(b1, b2))
+        self.assertEqual((s1 <= s2), (b1 <= b2))
+
+
+    @given(bitmap_cls, small_integer_list, small_integer_list)
+    def test_ge(self, BitMapClass, list1, list2):
+        if BitMapClass == BitMap:
+            SetClass = set
+        elif BitMapClass == FrozenBitMap:
+            SetClass = frozenset
+        else:
+            raise AssertionError()
+
+        s1 = SetClass(list1)
+        s2 = SetClass(list2)
+
+        b1 = BitMapClass(list1)
+        b2 = BitMapClass(list2)
+
+        self.assertEqual(s1.__ge__(s2), b1.__ge__(b2))
+        self.assertEqual(SetClass.__ge__(s1, s2), BitMapClass.__ge__(b1, b2))
+        self.assertEqual((s1 >= s2), (b1 >= b2))
+
+    @given(bitmap_cls, small_integer_list, small_integer_list)
+    def test_eq(self, BitMapClass, list1, list2):
+        if BitMapClass == BitMap:
+            SetClass = set
+        elif BitMapClass == FrozenBitMap:
+            SetClass = frozenset
+        else:
+            raise AssertionError()
+        s1 = SetClass(list1)
+        s2 = SetClass(list2)
+
+        b1 = BitMapClass(list1)
+        b2 = BitMapClass(list2)
+
+        self.assertEqual(s1.__eq__(s2), b1.__eq__(b2))
+        self.assertEqual(SetClass.__eq__(s1, s2), BitMapClass.__eq__(b1, b2))
+        self.assertEqual((s1 == s2), (b1 == b2))
+
+
     @given(bitmap_cls, small_integer_list, small_integer_list)
     def test_issuperset(self, BitMapClass, list1, list2):
         if BitMapClass == BitMap:

--- a/test.py
+++ b/test.py
@@ -874,8 +874,8 @@ class PythonSetEquivalentTest(unittest.TestCase):
     The main goal of this class is to make sure the BitMap api is a superset of the python builtin set api.
     """
 
-    @given(bitmap_cls, small_integer_list)
-    def test_convert_to_set(self, BitMapClass, list1):
+    @given(bitmap_cls, small_integer_list, st.booleans())
+    def test_convert_to_set(self, BitMapClass, list1, cow):
         """
         Most of the tests depend on a working implementation for converting from BitMap to python set.
         This test sanity checks it.
@@ -891,7 +891,7 @@ class PythonSetEquivalentTest(unittest.TestCase):
             raise AssertionError()
 
         s1 = SetClass(list1)
-        b1 = BitMapClass(list1)
+        b1 = BitMapClass(list1, copy_on_write=cow)
 
         converted_set = SetClass(b1)
 
@@ -909,8 +909,8 @@ class PythonSetEquivalentTest(unittest.TestCase):
             self.assertEqual(i in s1, i in converted_set)
 
 
-    @given(bitmap_cls, small_integer_list, small_integer_list)
-    def test_difference(self, BitMapClass, list1, list2):
+    @given(bitmap_cls, small_integer_list, small_integer_list, st.booleans())
+    def test_difference(self, BitMapClass, list1, list2, cow):
         if BitMapClass == BitMap:
             SetClass = set
         elif BitMapClass == FrozenBitMap:
@@ -921,16 +921,16 @@ class PythonSetEquivalentTest(unittest.TestCase):
         s1 = SetClass(list1)
         s2 = SetClass(list2)
 
-        b1 = BitMapClass(list1)
-        b2 = BitMapClass(list2)
+        b1 = BitMapClass(list1, copy_on_write=cow)
+        b2 = BitMapClass(list2, copy_on_write=cow)
 
         self.assertEqual(s1.difference(s2), set(b1.difference(b2)))
         self.assertEqual(SetClass.difference(s1, s2), set(BitMapClass.difference(b1, b2)))
         self.assertEqual((s1 - s2), set(b1 - b2))
         self.assertEqual(b1 - b2, b1.difference(b2))
 
-    @given(bitmap_cls, small_integer_list, small_integer_list)
-    def test_symmetric_difference(self, BitMapClass, list1, list2):
+    @given(bitmap_cls, small_integer_list, small_integer_list, st.booleans())
+    def test_symmetric_difference(self, BitMapClass, list1, list2, cow):
         if BitMapClass == BitMap:
             SetClass = set
         elif BitMapClass == FrozenBitMap:
@@ -941,14 +941,14 @@ class PythonSetEquivalentTest(unittest.TestCase):
         s1 = SetClass(list1)
         s2 = SetClass(list2)
 
-        b1 = BitMapClass(list1)
-        b2 = BitMapClass(list2)
+        b1 = BitMapClass(list1, copy_on_write=cow)
+        b2 = BitMapClass(list2, copy_on_write=cow)
 
         self.assertEqual(s1.symmetric_difference(s2), set(b1.symmetric_difference(b2)))
         self.assertEqual(SetClass.symmetric_difference(s1, s2), set(BitMapClass.symmetric_difference(b1, b2)))
 
-    @given(bitmap_cls, small_integer_list, small_integer_list)
-    def test_union(self, BitMapClass, list1, list2):
+    @given(bitmap_cls, small_integer_list, small_integer_list, st.booleans())
+    def test_union(self, BitMapClass, list1, list2, cow):
         if BitMapClass == BitMap:
             SetClass = set
         elif BitMapClass == FrozenBitMap:
@@ -959,16 +959,16 @@ class PythonSetEquivalentTest(unittest.TestCase):
         s1 = SetClass(list1)
         s2 = SetClass(list2)
 
-        b1 = BitMapClass(list1)
-        b2 = BitMapClass(list2)
+        b1 = BitMapClass(list1, copy_on_write=cow)
+        b2 = BitMapClass(list2, copy_on_write=cow)
 
         self.assertEqual(s1.union(s2), set(b1.union(b2)))
         self.assertEqual(SetClass.union(s1, s2), set(BitMapClass.union(b1, b2)))
         self.assertEqual((s1 | s2), set(b1 | b2))
         self.assertEqual(b1 | b2, b1.union(b2))
 
-    @given(bitmap_cls, small_integer_list, small_integer_list)
-    def test_issubset(self, BitMapClass, list1, list2):
+    @given(bitmap_cls, small_integer_list, small_integer_list, st.booleans())
+    def test_issubset(self, BitMapClass, list1, list2, cow):
         if BitMapClass == BitMap:
             SetClass = set
         elif BitMapClass == FrozenBitMap:
@@ -979,15 +979,15 @@ class PythonSetEquivalentTest(unittest.TestCase):
         s1 = SetClass(list1)
         s2 = SetClass(list2)
 
-        b1 = BitMapClass(list1)
-        b2 = BitMapClass(list2)
+        b1 = BitMapClass(list1, copy_on_write=cow)
+        b2 = BitMapClass(list2, copy_on_write=cow)
 
         self.assertEqual(s1.issubset(s2), b1.issubset(b2))
         self.assertEqual(SetClass.issubset(s1, s2), BitMapClass.issubset(b1, b2))
 
 
-    @given(bitmap_cls, small_integer_list, small_integer_list)
-    def test_le(self, BitMapClass, list1, list2):
+    @given(bitmap_cls, small_integer_list, small_integer_list, st.booleans())
+    def test_le(self, BitMapClass, list1, list2, cow):
         if BitMapClass == BitMap:
             SetClass = set
         elif BitMapClass == FrozenBitMap:
@@ -998,16 +998,16 @@ class PythonSetEquivalentTest(unittest.TestCase):
         s1 = SetClass(list1)
         s2 = SetClass(list2)
 
-        b1 = BitMapClass(list1)
-        b2 = BitMapClass(list2)
+        b1 = BitMapClass(list1, copy_on_write=cow)
+        b2 = BitMapClass(list2, copy_on_write=cow)
 
         self.assertEqual(s1.__le__(s2), b1.__le__(b2))
         self.assertEqual(SetClass.__le__(s1, s2), BitMapClass.__le__(b1, b2))
         self.assertEqual((s1 <= s2), (b1 <= b2))
 
 
-    @given(bitmap_cls, small_integer_list, small_integer_list)
-    def test_ge(self, BitMapClass, list1, list2):
+    @given(bitmap_cls, small_integer_list, small_integer_list, st.booleans())
+    def test_ge(self, BitMapClass, list1, list2, cow):
         if BitMapClass == BitMap:
             SetClass = set
         elif BitMapClass == FrozenBitMap:
@@ -1018,15 +1018,15 @@ class PythonSetEquivalentTest(unittest.TestCase):
         s1 = SetClass(list1)
         s2 = SetClass(list2)
 
-        b1 = BitMapClass(list1)
-        b2 = BitMapClass(list2)
+        b1 = BitMapClass(list1, copy_on_write=cow)
+        b2 = BitMapClass(list2, copy_on_write=cow)
 
         self.assertEqual(s1.__ge__(s2), b1.__ge__(b2))
         self.assertEqual(SetClass.__ge__(s1, s2), BitMapClass.__ge__(b1, b2))
         self.assertEqual((s1 >= s2), (b1 >= b2))
 
-    @given(bitmap_cls, small_integer_list, small_integer_list)
-    def test_eq(self, BitMapClass, list1, list2):
+    @given(bitmap_cls, small_integer_list, small_integer_list, st.booleans())
+    def test_eq(self, BitMapClass, list1, list2, cow):
         if BitMapClass == BitMap:
             SetClass = set
         elif BitMapClass == FrozenBitMap:
@@ -1036,16 +1036,16 @@ class PythonSetEquivalentTest(unittest.TestCase):
         s1 = SetClass(list1)
         s2 = SetClass(list2)
 
-        b1 = BitMapClass(list1)
-        b2 = BitMapClass(list2)
+        b1 = BitMapClass(list1, copy_on_write=cow)
+        b2 = BitMapClass(list2, copy_on_write=cow)
 
         self.assertEqual(s1.__eq__(s2), b1.__eq__(b2))
         self.assertEqual(SetClass.__eq__(s1, s2), BitMapClass.__eq__(b1, b2))
         self.assertEqual((s1 == s2), (b1 == b2))
 
 
-    @given(bitmap_cls, small_integer_list, small_integer_list)
-    def test_issuperset(self, BitMapClass, list1, list2):
+    @given(bitmap_cls, small_integer_list, small_integer_list, st.booleans())
+    def test_issuperset(self, BitMapClass, list1, list2, cow):
         if BitMapClass == BitMap:
             SetClass = set
         elif BitMapClass == FrozenBitMap:
@@ -1056,14 +1056,14 @@ class PythonSetEquivalentTest(unittest.TestCase):
         s1 = SetClass(list1)
         s2 = SetClass(list2)
 
-        b1 = BitMapClass(list1)
-        b2 = BitMapClass(list2)
+        b1 = BitMapClass(list1, copy_on_write=cow)
+        b2 = BitMapClass(list2, copy_on_write=cow)
 
         self.assertEqual(s1.issuperset(s2), b1.issuperset(b2))
         self.assertEqual(SetClass.issuperset(s1, s2), BitMapClass.issuperset(b1, b2))
 
-    @given(bitmap_cls, small_integer_list, small_integer_list)
-    def test_isdisjoint(self, BitMapClass, list1, list2):
+    @given(bitmap_cls, small_integer_list, small_integer_list, st.booleans())
+    def test_isdisjoint(self, BitMapClass, list1, list2, cow):
         if BitMapClass == BitMap:
             SetClass = set
         elif BitMapClass == FrozenBitMap:
@@ -1074,22 +1074,22 @@ class PythonSetEquivalentTest(unittest.TestCase):
         s1 = SetClass(list1)
         s2 = SetClass(list2)
 
-        b1 = BitMapClass(list1)
-        b2 = BitMapClass(list2)
+        b1 = BitMapClass(list1, copy_on_write=cow)
+        b2 = BitMapClass(list2, copy_on_write=cow)
 
         self.assertEqual(s1.isdisjoint(s2), b1.isdisjoint(b2))
         self.assertEqual(SetClass.isdisjoint(s1, s2), BitMapClass.isdisjoint(b1, b2))
 
 
-    @given(small_integer_list)
-    def test_clear(self, list1):
-        b1 = BitMap(list1)
+    @given(small_integer_list,  st.booleans())
+    def test_clear(self, list1, cow):
+        b1 = BitMap(list1, copy_on_write=cow)
         b1.clear()
         self.assertEqual(len(b1), 0)
 
-    @given(small_integer_list)
-    def test_pop(self, list1):
-        b1 = BitMap(list1)
+    @given(small_integer_list, st.booleans())
+    def test_pop(self, list1, cow):
+        b1 = BitMap(list1, copy_on_write=cow)
         starting_length = len(b1)
         if starting_length >= 1:
             popped_element = b1.pop()
@@ -1099,16 +1099,16 @@ class PythonSetEquivalentTest(unittest.TestCase):
             with self.assertRaises(KeyError):
                 b1.pop()
 
-    @given(bitmap_cls, small_integer_list)
-    def test_copy(self, BitMapClass, list1):
-        b1 = BitMapClass(list1)
+    @given(bitmap_cls, small_integer_list, st.booleans())
+    def test_copy(self, BitMapClass, list1, cow):
+        b1 = BitMapClass(list1, copy_on_write=cow)
         b2 = b1.copy()
         self.assertEqual(b2, b1)
 
 
-    @given(small_integer_list)
-    def test_copy_writable(self, list1):
-        b1 = BitMap(list1)
+    @given(small_integer_list, st.booleans())
+    def test_copy_writable(self, list1, cow):
+        b1 = BitMap(list1, copy_on_write=cow)
         b2 = b1.copy()
 
         try:
@@ -1121,33 +1121,33 @@ class PythonSetEquivalentTest(unittest.TestCase):
         self.assertTrue(new_element in b2)
         self.assertTrue(new_element not in b1)
 
-    @given(small_integer_list, small_integer_list)
-    def test_difference_update(self, list1, list2):
+    @given(small_integer_list, small_integer_list, st.booleans())
+    def test_difference_update(self, list1, list2, cow):
         s1 = set(list1)
         s2 = set(list2)
         s1.difference_update(s2)
 
-        b1 = BitMap(list1)
-        b2 = BitMap(list2)
+        b1 = BitMap(list1, copy_on_write=cow)
+        b2 = BitMap(list2, copy_on_write=cow)
         b1.difference_update(b2)
 
         self.assertEqual(s1, set(b1))
 
-    @given(small_integer_list, small_integer_list)
-    def test_symmetric_difference_update(self, list1, list2):
+    @given(small_integer_list, small_integer_list, st.booleans())
+    def test_symmetric_difference_update(self, list1, list2, cow):
         s1 = set(list1)
         s2 = set(list2)
         s1.symmetric_difference_update(s2)
 
-        b1 = BitMap(list1)
-        b2 = BitMap(list2)
+        b1 = BitMap(list1, copy_on_write=cow)
+        b2 = BitMap(list2, copy_on_write=cow)
         b1.symmetric_difference_update(b2)
 
         self.assertEqual(s1, set(b1))
 
 
-    @given(bitmap_cls, small_integer_list, small_integer_list)
-    def test_dunder(self, BitMapClass, list1, list2):
+    @given(bitmap_cls, small_integer_list, small_integer_list, st.booleans())
+    def test_dunder(self, BitMapClass, list1, list2, cow):
         """
         Tests for &|^-
         """
@@ -1161,38 +1161,38 @@ class PythonSetEquivalentTest(unittest.TestCase):
         s1 = SetClass(list1)
         s2 = SetClass(list2)
 
-        b1 = BitMapClass(list1)
-        b2 = BitMapClass(list2)
+        b1 = BitMapClass(list1, copy_on_write=cow)
+        b2 = BitMapClass(list2, copy_on_write=cow)
 
         self.assertEqual(s1.__and__(s2), SetClass(b1.__and__(b2)))
         self.assertEqual(s1.__or__(s2), SetClass(b1.__or__(b2)))
         self.assertEqual(s1.__xor__(s2), SetClass(b1.__xor__(b2)))
         self.assertEqual(s1.__sub__(s2), SetClass(b1.__sub__(b2)))
 
-    @given(small_integer_list, small_integer)
-    def test_add(self, list1, value):
+    @given(small_integer_list, small_integer, st.booleans())
+    def test_add(self, list1, value, cow):
         s1 = set(list1)
-        b1 = BitMap(list1)
+        b1 = BitMap(list1, copy_on_write=cow)
         self.assertEqual(s1, set(b1))
 
         s1.add(value)
         b1.add(value)
         self.assertEqual(s1, set(b1))
 
-    @given(small_integer_list, small_integer)
-    def test_discard(self, list1, value):
+    @given(small_integer_list, small_integer, st.booleans())
+    def test_discard(self, list1, value, cow):
         s1 = set(list1)
-        b1 = BitMap(list1)
+        b1 = BitMap(list1, copy_on_write=cow)
         self.assertEqual(s1, set(b1))
 
         s1.discard(value)
         b1.discard(value)
         self.assertEqual(s1, set(b1))
 
-    @given(small_integer_list, small_integer)
-    def test_remove(self, list1, value):
+    @given(small_integer_list, small_integer, st.booleans())
+    def test_remove(self, list1, value, cow):
         s1 = set(list1)
-        b1 = BitMap(list1)
+        b1 = BitMap(list1, copy_on_write=cow)
         self.assertEqual(s1, set(b1))
 
         s1_raised = False
@@ -1210,8 +1210,8 @@ class PythonSetEquivalentTest(unittest.TestCase):
         self.assertEqual(s1, set(b1))
         self.assertEqual(s1_raised, b1_raised) #Either both raised exception or neither did
 
-    @given(bitmap_cls, small_integer_list, small_integer_list, small_integer_list)
-    def test_nary_union(self, BitMapClass, list1, list2, list3):
+    @given(bitmap_cls, small_integer_list, small_integer_list, small_integer_list, st.booleans())
+    def test_nary_union(self, BitMapClass, list1, list2, list3, cow):
         if BitMapClass == BitMap:
             SetClass = set
         elif BitMapClass == FrozenBitMap:
@@ -1223,15 +1223,15 @@ class PythonSetEquivalentTest(unittest.TestCase):
         s2 = SetClass(list2)
         s3 = SetClass(list3)
 
-        b1 = BitMapClass(list1)
-        b2 = BitMapClass(list2)
-        b3 = BitMapClass(list3)
+        b1 = BitMapClass(list1, copy_on_write=cow)
+        b2 = BitMapClass(list2, copy_on_write=cow)
+        b3 = BitMapClass(list3, copy_on_write=cow)
 
         self.assertEqual(SetClass.union(s1, s2, s3), SetClass(BitMapClass.union(b1, b2, b3)))
         self.assertEqual(s1.union(s2, s3), SetClass(b1.union(b2, b3)))
 
-    @given(bitmap_cls, small_integer_list, small_integer_list, small_integer_list)
-    def test_nary_difference(self, BitMapClass, list1, list2, list3):
+    @given(bitmap_cls, small_integer_list, small_integer_list, small_integer_list, st.booleans())
+    def test_nary_difference(self, BitMapClass, list1, list2, list3, cow):
         if BitMapClass == BitMap:
             SetClass = set
         elif BitMapClass == FrozenBitMap:
@@ -1243,15 +1243,15 @@ class PythonSetEquivalentTest(unittest.TestCase):
         s2 = SetClass(list2)
         s3 = SetClass(list3)
 
-        b1 = BitMapClass(list1)
-        b2 = BitMapClass(list2)
-        b3 = BitMapClass(list3)
+        b1 = BitMapClass(list1, copy_on_write=cow)
+        b2 = BitMapClass(list2, copy_on_write=cow)
+        b3 = BitMapClass(list3, copy_on_write=cow)
 
         self.assertEqual(SetClass.difference(s1, s2, s3), SetClass(BitMapClass.difference(b1, b2, b3)))
         self.assertEqual(s1.difference(s2, s3), SetClass(b1.difference(b2, b3)))
 
-    @given(bitmap_cls, small_integer_list, small_integer_list, small_integer_list)
-    def test_nary_intersection(self, BitMapClass, list1, list2, list3):
+    @given(bitmap_cls, small_integer_list, small_integer_list, small_integer_list, st.booleans())
+    def test_nary_intersection(self, BitMapClass, list1, list2, list3, cow):
         if BitMapClass == BitMap:
             SetClass = set
         elif BitMapClass == FrozenBitMap:
@@ -1263,22 +1263,22 @@ class PythonSetEquivalentTest(unittest.TestCase):
         s2 = SetClass(list2)
         s3 = SetClass(list3)
 
-        b1 = BitMapClass(list1)
-        b2 = BitMapClass(list2)
-        b3 = BitMapClass(list3)
+        b1 = BitMapClass(list1, copy_on_write=cow)
+        b2 = BitMapClass(list2, copy_on_write=cow)
+        b3 = BitMapClass(list3, copy_on_write=cow)
 
         self.assertEqual(SetClass.intersection(s1, s2, s3), SetClass(BitMapClass.intersection(b1, b2, b3)))
         self.assertEqual(s1.intersection(s2, s3), SetClass(b1.intersection(b2, b3)))
 
-    @given(small_integer_list, small_integer_list, small_integer_list)
-    def test_nary_intersection_update(self, list1, list2, list3):
+    @given(small_integer_list, small_integer_list, small_integer_list, st.booleans())
+    def test_nary_intersection_update(self, list1, list2, list3, cow):
         s1 = set(list1)
         s2 = set(list2)
         s3 = set(list3)
 
-        b1 = BitMap(list1)
-        b2 = BitMap(list2)
-        b3 = BitMap(list3)
+        b1 = BitMap(list1, copy_on_write=cow)
+        b2 = BitMap(list2, copy_on_write=cow)
+        b3 = BitMap(list3, copy_on_write=cow)
 
         set.intersection_update(s1, s2, s3)
         BitMap.intersection_update(b1, b2, b3)
@@ -1289,9 +1289,9 @@ class PythonSetEquivalentTest(unittest.TestCase):
         s2 = set(list2)
         s3 = set(list3)
 
-        b1 = BitMap(list1)
-        b2 = BitMap(list2)
-        b3 = BitMap(list3)
+        b1 = BitMap(list1, copy_on_write=cow)
+        b2 = BitMap(list2, copy_on_write=cow)
+        b3 = BitMap(list3, copy_on_write=cow)
 
         s1.intersection_update(s2, s3)
         b1.intersection_update(b2, b3)
@@ -1299,15 +1299,15 @@ class PythonSetEquivalentTest(unittest.TestCase):
         self.assertEqual(s1, set(b1))
 
 
-    @given(small_integer_list, small_integer_list, small_integer_list)
-    def test_nary_difference_update(self, list1, list2, list3):
+    @given(small_integer_list, small_integer_list, small_integer_list, st.booleans())
+    def test_nary_difference_update(self, list1, list2, list3, cow):
         s1 = set(list1)
         s2 = set(list2)
         s3 = set(list3)
 
-        b1 = BitMap(list1)
-        b2 = BitMap(list2)
-        b3 = BitMap(list3)
+        b1 = BitMap(list1, copy_on_write=cow)
+        b2 = BitMap(list2, copy_on_write=cow)
+        b3 = BitMap(list3, copy_on_write=cow)
 
         set.difference_update(s1, s2, s3)
         BitMap.difference_update(b1, b2, b3)
@@ -1318,24 +1318,24 @@ class PythonSetEquivalentTest(unittest.TestCase):
         s2 = set(list2)
         s3 = set(list3)
 
-        b1 = BitMap(list1)
-        b2 = BitMap(list2)
-        b3 = BitMap(list3)
+        b1 = BitMap(list1, copy_on_write=cow)
+        b2 = BitMap(list2, copy_on_write=cow)
+        b3 = BitMap(list3, copy_on_write=cow)
 
         s1.difference_update(s2, s3)
         b1.difference_update(b2, b3)
 
         self.assertEqual(s1, set(b1))
 
-    @given(small_integer_list, small_integer_list, small_integer_list)
-    def test_nary_update(self, list1, list2, list3):
+    @given(small_integer_list, small_integer_list, small_integer_list, st.booleans())
+    def test_nary_update(self, list1, list2, list3, cow):
         s1 = set(list1)
         s2 = set(list2)
         s3 = set(list3)
 
-        b1 = BitMap(list1)
-        b2 = BitMap(list2)
-        b3 = BitMap(list3)
+        b1 = BitMap(list1, copy_on_write=cow)
+        b2 = BitMap(list2, copy_on_write=cow)
+        b3 = BitMap(list3, copy_on_write=cow)
 
         set.update(s1, s2, s3)
         BitMap.update(b1, b2, b3)
@@ -1346,9 +1346,9 @@ class PythonSetEquivalentTest(unittest.TestCase):
         s2 = set(list2)
         s3 = set(list3)
 
-        b1 = BitMap(list1)
-        b2 = BitMap(list2)
-        b3 = BitMap(list3)
+        b1 = BitMap(list1, copy_on_write=cow)
+        b2 = BitMap(list2, copy_on_write=cow)
+        b3 = BitMap(list3, copy_on_write=cow)
 
         s1.update(s2, s3)
         b1.update(b2, b3)

--- a/test.py
+++ b/test.py
@@ -531,7 +531,6 @@ class ManyOperationsTest(Util):
         expected_result = functools.reduce(
             lambda x, y: x | y, self.all_bitmaps)
         self.assertEqual(expected_result, result)
-        self.assertIsInstance(result, cls)
 
     @given(bitmap_cls, st.data(), hyp_many_collections, st.booleans())
     def test_intersection(self, cls, data, all_values, cow):
@@ -542,7 +541,6 @@ class ManyOperationsTest(Util):
         expected_result = functools.reduce(
             lambda x, y: x & y, self.all_bitmaps)
         self.assertEqual(expected_result, result)
-        self.assertIsInstance(result, cls)
 
 
 class SerializationTest(Util):
@@ -772,6 +770,10 @@ class FrozenTest(unittest.TestCase):
             frozen -= other
         self.assertEqual(frozen, copy)
         with self.assertRaises(AttributeError):
+            frozen.clear()
+        with self.assertRaises(AttributeError):
+            frozen.pop()
+        with self.assertRaises(AttributeError):
             frozen.add(number)
         with self.assertRaises(AttributeError):
             frozen.update(other)
@@ -781,6 +783,10 @@ class FrozenTest(unittest.TestCase):
             frozen.remove(number)
         with self.assertRaises(AttributeError):
             frozen.intersection_update(other)
+        with self.assertRaises(AttributeError):
+            frozen.difference_update(other)
+        with self.assertRaises(AttributeError):
+            frozen.symmetric_difference_update(other)
         with self.assertRaises(AttributeError):
             frozen.update(number, number+10)
         self.assertEqual(frozen, copy)
@@ -847,6 +853,422 @@ class OptimizationTest(unittest.TestCase):
         self.assertEqual(bm2.shrink_to_fit(), 0)
         bm3 = cls(bm1, optimize=True)
         self.assertEqual(bm3.shrink_to_fit(), 0)
+
+small_integer = st.integers(min_value=0, max_value=200)
+small_integer_list = st.lists(min_size=0, max_size=2000, elements=small_integer)
+class PythonSetEquivalentTest(unittest.TestCase):
+    """
+    The main goal of this class is to make sure the BitMap api is a superset of the python builtin set api.
+    """
+
+    @given(bitmap_cls, small_integer_list)
+    def test_convert_to_set(self, BitMapClass, list1):
+        """
+        Most of the tests depend on a working implementation for converting from BitMap to python set.
+        This test sanity checks it.
+
+        This test should be modified or removed if you want to run PythonSetEquivalentTest with integers drawn from
+        a larger set than `small_integer`. It will become prohibitively time-consuming.
+        """
+        if BitMapClass == BitMap:
+            SetClass = set
+        elif BitMapClass == FrozenBitMap:
+            SetClass = frozenset
+        else:
+            raise AssertionError()
+
+        s1 = SetClass(list1)
+        b1 = BitMapClass(list1)
+
+        converted_set = SetClass(b1)
+
+        min_value, max_value = min(s1, default=0), max(s1, default=200) + 1
+        for i in range(min_value, max_value):
+            self.assertEqual(i in s1, i in converted_set)
+
+
+    @given(bitmap_cls, small_integer_list, small_integer_list)
+    def test_difference(self, BitMapClass, list1, list2):
+        if BitMapClass == BitMap:
+            SetClass = set
+        elif BitMapClass == FrozenBitMap:
+            SetClass = frozenset
+        else:
+            raise AssertionError()
+
+        s1 = SetClass(list1)
+        s2 = SetClass(list2)
+
+        b1 = BitMapClass(list1)
+        b2 = BitMapClass(list2)
+
+        self.assertEqual(s1.difference(s2), set(b1.difference(b2)))
+        self.assertEqual(SetClass.difference(s1, s2), set(BitMapClass.difference(b1, b2)))
+        self.assertEqual((s1 - s2), set(b1 - b2))
+        self.assertEqual(b1 - b2, b1.difference(b2))
+
+    @given(bitmap_cls, small_integer_list, small_integer_list)
+    def test_symmetric_difference(self, BitMapClass, list1, list2):
+        if BitMapClass == BitMap:
+            SetClass = set
+        elif BitMapClass == FrozenBitMap:
+            SetClass = frozenset
+        else:
+            raise AssertionError()
+
+        s1 = SetClass(list1)
+        s2 = SetClass(list2)
+
+        b1 = BitMapClass(list1)
+        b2 = BitMapClass(list2)
+
+        self.assertEqual(s1.symmetric_difference(s2), set(b1.symmetric_difference(b2)))
+        self.assertEqual(SetClass.symmetric_difference(s1, s2), set(BitMapClass.symmetric_difference(b1, b2)))
+
+    @given(bitmap_cls, small_integer_list, small_integer_list)
+    def test_union(self, BitMapClass, list1, list2):
+        if BitMapClass == BitMap:
+            SetClass = set
+        elif BitMapClass == FrozenBitMap:
+            SetClass = frozenset
+        else:
+            raise AssertionError()
+
+        s1 = SetClass(list1)
+        s2 = SetClass(list2)
+
+        b1 = BitMapClass(list1)
+        b2 = BitMapClass(list2)
+
+        self.assertEqual(s1.union(s2), set(b1.union(b2)))
+        self.assertEqual(SetClass.union(s1, s2), set(BitMapClass.union(b1, b2)))
+        self.assertEqual((s1 | s2), set(b1 | b2))
+        self.assertEqual(b1 | b2, b1.union(b2))
+
+    @given(bitmap_cls, small_integer_list, small_integer_list)
+    def test_issubset(self, BitMapClass, list1, list2):
+        if BitMapClass == BitMap:
+            SetClass = set
+        elif BitMapClass == FrozenBitMap:
+            SetClass = frozenset
+        else:
+            raise AssertionError()
+
+        s1 = SetClass(list1)
+        s2 = SetClass(list2)
+
+        b1 = BitMapClass(list1)
+        b2 = BitMapClass(list2)
+
+        self.assertEqual(s1.issubset(s2), b1.issubset(b2))
+        self.assertEqual(SetClass.issubset(s1, s2), BitMapClass.issubset(b1, b2))
+
+    @given(bitmap_cls, small_integer_list, small_integer_list)
+    def test_issuperset(self, BitMapClass, list1, list2):
+        if BitMapClass == BitMap:
+            SetClass = set
+        elif BitMapClass == FrozenBitMap:
+            SetClass = frozenset
+        else:
+            raise AssertionError()
+
+        s1 = SetClass(list1)
+        s2 = SetClass(list2)
+
+        b1 = BitMapClass(list1)
+        b2 = BitMapClass(list2)
+
+        self.assertEqual(s1.issuperset(s2), b1.issuperset(b2))
+        self.assertEqual(SetClass.issuperset(s1, s2), BitMapClass.issuperset(b1, b2))
+
+    @given(bitmap_cls, small_integer_list, small_integer_list)
+    def test_isdisjoint(self, BitMapClass, list1, list2):
+        if BitMapClass == BitMap:
+            SetClass = set
+        elif BitMapClass == FrozenBitMap:
+            SetClass = frozenset
+        else:
+            raise AssertionError()
+
+        s1 = SetClass(list1)
+        s2 = SetClass(list2)
+
+        b1 = BitMapClass(list1)
+        b2 = BitMapClass(list2)
+
+        self.assertEqual(s1.isdisjoint(s2), b1.isdisjoint(b2))
+        self.assertEqual(SetClass.isdisjoint(s1, s2), BitMapClass.isdisjoint(b1, b2))
+
+
+    @given(small_integer_list)
+    def test_clear(self, list1):
+        b1 = BitMap(list1)
+        b1.clear()
+        self.assertEqual(len(b1), 0)
+
+    @given(small_integer_list)
+    def test_pop(self, list1):
+        b1 = BitMap(list1)
+        starting_length = len(b1)
+        if starting_length >= 1:
+            popped_element = b1.pop()
+            self.assertEqual(len(b1), starting_length - 1) #length decreased by one
+            self.assertFalse(popped_element in b1) #and element isn't in the BitMap anymore
+        else:
+            with self.assertRaises(KeyError):
+                b1.pop()
+
+    @given(bitmap_cls, small_integer_list)
+    def test_copy(self, BitMapClass, list1):
+        b1 = BitMapClass(list1)
+        b2 = b1.copy()
+        self.assertEqual(b2, b1)
+
+
+    @given(small_integer_list)
+    def test_copy_writable(self, list1):
+        b1 = BitMap(list1)
+        b2 = b1.copy()
+
+        new_element = max(b1, default = 0) + 1 #doesn't exist in the set
+        b2.add(new_element)
+
+        self.assertTrue(new_element in b2)
+        self.assertTrue(new_element not in b1)
+
+    @given(small_integer_list, small_integer_list)
+    def test_difference_update(self, list1, list2):
+        s1 = set(list1)
+        s2 = set(list2)
+        s1.difference_update(s2)
+
+        b1 = BitMap(list1)
+        b2 = BitMap(list2)
+        b1.difference_update(b2)
+
+        self.assertEqual(s1, set(b1))
+
+    @given(small_integer_list, small_integer_list)
+    def test_symmetric_difference_update(self, list1, list2):
+        s1 = set(list1)
+        s2 = set(list2)
+        s1.symmetric_difference_update(s2)
+
+        b1 = BitMap(list1)
+        b2 = BitMap(list2)
+        b1.symmetric_difference_update(b2)
+
+        self.assertEqual(s1, set(b1))
+
+
+    @given(bitmap_cls, small_integer_list, small_integer_list)
+    def test_dunder(self, BitMapClass, list1, list2):
+        """
+        Tests for &|^-
+        """
+        if BitMapClass == BitMap:
+            SetClass = set
+        elif BitMapClass == FrozenBitMap:
+            SetClass = frozenset
+        else:
+            raise AssertionError()
+
+        s1 = SetClass(list1)
+        s2 = SetClass(list2)
+
+        b1 = BitMapClass(list1)
+        b2 = BitMapClass(list2)
+
+        self.assertEqual(s1.__and__(s2), SetClass(b1.__and__(b2)))
+        self.assertEqual(s1.__or__(s2), SetClass(b1.__or__(b2)))
+        self.assertEqual(s1.__xor__(s2), SetClass(b1.__xor__(b2)))
+        self.assertEqual(s1.__sub__(s2), SetClass(b1.__sub__(b2)))
+
+    @given(small_integer_list, small_integer)
+    def test_add(self, list1, value):
+        s1 = set(list1)
+        b1 = BitMap(list1)
+        self.assertEqual(s1, set(b1))
+
+        s1.add(value)
+        b1.add(value)
+        self.assertEqual(s1, set(b1))
+
+    @given(small_integer_list, small_integer)
+    def test_discard(self, list1, value):
+        s1 = set(list1)
+        b1 = BitMap(list1)
+        self.assertEqual(s1, set(b1))
+
+        s1.discard(value)
+        b1.discard(value)
+        self.assertEqual(s1, set(b1))
+
+    @given(small_integer_list, small_integer)
+    def test_remove(self, list1, value):
+        s1 = set(list1)
+        b1 = BitMap(list1)
+        self.assertEqual(s1, set(b1))
+
+        s1_raised = False
+        b1_raised = False
+        try:
+            s1.remove(value)
+        except KeyError:
+            s1_raised = True
+
+        try:
+            b1.remove(value)
+        except KeyError:
+            b1_raised = True
+
+        self.assertEqual(s1, set(b1))
+        self.assertEqual(s1_raised, b1_raised) #Either both raised exception or neither did
+
+    @given(bitmap_cls, small_integer_list, small_integer_list, small_integer_list)
+    def test_nary_union(self, BitMapClass, list1, list2, list3):
+        if BitMapClass == BitMap:
+            SetClass = set
+        elif BitMapClass == FrozenBitMap:
+            SetClass = frozenset
+        else:
+            raise AssertionError()
+
+        s1 = SetClass(list1)
+        s2 = SetClass(list2)
+        s3 = SetClass(list3)
+
+        b1 = BitMapClass(list1)
+        b2 = BitMapClass(list2)
+        b3 = BitMapClass(list3)
+
+        self.assertEqual(SetClass.union(s1, s2, s3), SetClass(BitMapClass.union(b1, b2, b3)))
+        self.assertEqual(s1.union(s2, s3), SetClass(b1.union(b2, b3)))
+
+    @given(bitmap_cls, small_integer_list, small_integer_list, small_integer_list)
+    def test_nary_difference(self, BitMapClass, list1, list2, list3):
+        if BitMapClass == BitMap:
+            SetClass = set
+        elif BitMapClass == FrozenBitMap:
+            SetClass = frozenset
+        else:
+            raise AssertionError()
+
+        s1 = SetClass(list1)
+        s2 = SetClass(list2)
+        s3 = SetClass(list3)
+
+        b1 = BitMapClass(list1)
+        b2 = BitMapClass(list2)
+        b3 = BitMapClass(list3)
+
+        self.assertEqual(SetClass.difference(s1, s2, s3), SetClass(BitMapClass.difference(b1, b2, b3)))
+        self.assertEqual(s1.difference(s2, s3), SetClass(b1.difference(b2, b3)))
+
+    @given(bitmap_cls, small_integer_list, small_integer_list, small_integer_list)
+    def test_nary_intersection(self, BitMapClass, list1, list2, list3):
+        if BitMapClass == BitMap:
+            SetClass = set
+        elif BitMapClass == FrozenBitMap:
+            SetClass = frozenset
+        else:
+            raise AssertionError()
+
+        s1 = SetClass(list1)
+        s2 = SetClass(list2)
+        s3 = SetClass(list3)
+
+        b1 = BitMapClass(list1)
+        b2 = BitMapClass(list2)
+        b3 = BitMapClass(list3)
+
+        self.assertEqual(SetClass.intersection(s1, s2, s3), SetClass(BitMapClass.intersection(b1, b2, b3)))
+        self.assertEqual(s1.intersection(s2, s3), SetClass(b1.intersection(b2, b3)))
+
+    @given(small_integer_list, small_integer_list, small_integer_list)
+    def test_nary_intersection_update(self, list1, list2, list3):
+        s1 = set(list1)
+        s2 = set(list2)
+        s3 = set(list3)
+
+        b1 = BitMap(list1)
+        b2 = BitMap(list2)
+        b3 = BitMap(list3)
+
+        set.intersection_update(s1, s2, s3)
+        BitMap.intersection_update(b1, b2, b3)
+        self.assertEqual(s1, set(b1))
+
+
+        s1 = set(list1)
+        s2 = set(list2)
+        s3 = set(list3)
+
+        b1 = BitMap(list1)
+        b2 = BitMap(list2)
+        b3 = BitMap(list3)
+
+        s1.intersection_update(s2, s3)
+        b1.intersection_update(b2, b3)
+
+        self.assertEqual(s1, set(b1))
+
+
+    @given(small_integer_list, small_integer_list, small_integer_list)
+    def test_nary_difference_update(self, list1, list2, list3):
+        s1 = set(list1)
+        s2 = set(list2)
+        s3 = set(list3)
+
+        b1 = BitMap(list1)
+        b2 = BitMap(list2)
+        b3 = BitMap(list3)
+
+        set.difference_update(s1, s2, s3)
+        BitMap.difference_update(b1, b2, b3)
+        self.assertEqual(s1, set(b1))
+
+
+        s1 = set(list1)
+        s2 = set(list2)
+        s3 = set(list3)
+
+        b1 = BitMap(list1)
+        b2 = BitMap(list2)
+        b3 = BitMap(list3)
+
+        s1.difference_update(s2, s3)
+        b1.difference_update(b2, b3)
+
+        self.assertEqual(s1, set(b1))
+
+    @given(small_integer_list, small_integer_list, small_integer_list)
+    def test_nary_update(self, list1, list2, list3):
+        s1 = set(list1)
+        s2 = set(list2)
+        s3 = set(list3)
+
+        b1 = BitMap(list1)
+        b2 = BitMap(list2)
+        b3 = BitMap(list3)
+
+        set.update(s1, s2, s3)
+        BitMap.update(b1, b2, b3)
+        self.assertEqual(s1, set(b1))
+
+
+        s1 = set(list1)
+        s2 = set(list2)
+        s3 = set(list3)
+
+        b1 = BitMap(list1)
+        b2 = BitMap(list2)
+        b3 = BitMap(list3)
+
+        s1.update(s2, s3)
+        b1.update(b2, b3)
+
+        self.assertEqual(s1, set(b1))
 
 
 class VersionTest(unittest.TestCase):


### PR DESCRIPTION
Worked on ideas from #37
 
This pull request adds the methods:

* `isdisjoint`
* `issubset`
* `issuperset`
* `difference`
* `symmetric_difference`
* `copy`
* `difference_update`
* `symmetric_difference_update`
* `clear`
* `pop`

It changes the behavior of `union` and `intersection`. They are no longer class methods
```python
a = BitMap([1, 2])
b = BitMap([3, 4])
c = BitMap([4, 5])
a.union(b, c) #BitMap([1, 2, 3, 4, 5])
BitMap.union(a, b, c) #BitMap([1, 2, 3, 4, 5])

#NB! Despite being called from FrozenBitMap, the type of the result is taken from the first argument
FrozenBitMap.union(a,b,c) #BitMap([1, 2, 3, 4, 5])
BitMap.union(FrozenBitMap(a), b, c) #FrozenBitMap([1, 2, 3, 4, 5])

#For native sets the behaviour is even more restrictive.
set1 = set([1, 2])
set2 = set([3, 4])
set.union(set1, frozenset(set2))  #{1, 2, 3, 4}
set.union(frozenset(set1), set2)  #TypeError
``` 
The implementation of `union` in this pull request seemed to be a bit faster than the previous one in quick tests. This seems surprising and needs a closer look. It might have been an artifact of the random data I used for testing.

- [x] add doctests for new methods
- [x] benchmark previous `union` and `intersection` against new ones with more diverse data
