### PR TITLE
Expose roaring_bitmap_portable_size_in_bytes as __sizeof__.

### DIFF
--- a/pyroaring/abstract_bitmap.pxi
+++ b/pyroaring/abstract_bitmap.pxi
@@ -634,6 +634,12 @@ cdef class AbstractBitMap:
         except TypeError:
             self._c_bitmap = deserialize_ptr(state.encode())
 
+
+    def __sizeof__(self):
+        cdef size_t size = croaring.roaring_bitmap_portable_size_in_bytes(self._c_bitmap)
+        return size
+
+
     def to_array(self):
         """
         Return an array.array containing the elements of the bitmap, in increasing order.


### PR DESCRIPTION
This allows `sys.getsizeof` to give more reasonable estimates about memory use of bitmaps.

Setup:
```python
import random
from pyroaring import BitMap
import sys
large_random_set = set(random.randint(1,10**6) for i in range(100_000))
```
Before implementing `__sizeof__`
```python
sys.getsizeof(BitMap(large_random_set)) #40
```
After implementing `__sizeof__`
```python
sys.getsizeof(BitMap(large_random_set)) #126240
```

According to python documentation `sys.getsizeof()` doesn't have to return correct results for third-party extensions. So even if `roaring_bitmap_portable_size_in_bytes` isn't the exact size of a BitMap in memory, I'd consider it an improvement over the default of returning 40 bytes in all cases.