### PR TITLE
Change __repr__ and __str__ to truncate very large BitMaps.

### DIFF
--- a/pyroaring/abstract_bitmap.pxi
+++ b/pyroaring/abstract_bitmap.pxi
@@ -213,7 +213,7 @@ cdef class AbstractBitMap:
 
         num_columns = table_max_width // column_width
 
-        num_rows = len(self) / num_columns
+        num_rows = len(self) / float(num_columns)
         if not num_rows.is_integer():
             num_rows += 1
         num_rows = int(num_rows)

--- a/pyroaring/abstract_bitmap.pxi
+++ b/pyroaring/abstract_bitmap.pxi
@@ -194,8 +194,58 @@ cdef class AbstractBitMap:
         return str(self)
 
     def __str__(self):
-        values = ', '.join([str(n) for n in self])
-        return '%s([%s])' % (self.__class__.__name__, values)
+        skip_rows = len(self) > 500
+        table_max_width = 80 #this isn't the length of the entire output, it's only for the numeric part
+        num_lines_if_skipping = 5 #the number of lines to show when output is being truncated
+
+        head = self.__class__.__name__ + '(['
+        row_start_buffer = ' ' * len(head)
+        tail = '])'
+
+        try:
+            maxval = self.max()
+        except ValueError:
+            #empty bitmap
+            return head + tail
+
+        element_max_length = len(str(maxval))
+        column_width = element_max_length + 2
+
+        num_columns = table_max_width // column_width
+
+        num_rows = len(self) / num_columns
+        if not num_rows.is_integer():
+            num_rows += 1
+        num_rows = int(num_rows)
+        rows = []
+        row_idx = 0
+        skipped = False
+        while row_idx < num_rows:
+            row_ints = self[row_idx * num_columns:(row_idx + 1) * num_columns]
+
+            line = []
+            for i in row_ints:
+                s = str(i)
+                if num_rows == 1:
+                    #no padding if all numbers fit on a single line
+                    line.append(s)
+                else:
+                    line.append(' '*(element_max_length-len(s)) + s)
+
+            if row_idx == 0:
+                prefix = head
+            else:
+                prefix = row_start_buffer
+            rows.append(prefix + ', '.join(line) + ',')
+            row_idx += 1
+            if skip_rows and not skipped and row_idx >= num_lines_if_skipping:
+                rows.append((' '* ((table_max_width + len(head)) // 2) )+  '...')
+                skipped = True
+                row_idx = num_rows - num_lines_if_skipping
+
+
+        rows[-1] = rows[-1].rstrip(',') #remove last comma
+        return '\n'.join(rows) + tail
 
     def flip(self, uint64_t start, uint64_t end):
         """

--- a/pyroaring/abstract_bitmap.pxi
+++ b/pyroaring/abstract_bitmap.pxi
@@ -194,9 +194,9 @@ cdef class AbstractBitMap:
         return str(self)
 
     def __str__(self):
-        skip_rows = len(self) > 500
-        table_max_width = 80 #this isn't the length of the entire output, it's only for the numeric part
-        num_lines_if_skipping = 5 #the number of lines to show when output is being truncated
+        skip_rows = len(self) > 500 #this is the cutoff number for the truncating to kick in.
+        table_max_width = 80  # this isn't the length of the entire output, it's only for the numeric part
+        num_lines_if_skipping = 5  # the number of lines to show in the beginning and the end when output is being truncated
 
         head = self.__class__.__name__ + '(['
         row_start_buffer = ' ' * len(head)
@@ -205,7 +205,7 @@ cdef class AbstractBitMap:
         try:
             maxval = self.max()
         except ValueError:
-            #empty bitmap
+            # empty bitmap
             return head + tail
 
         element_max_length = len(str(maxval))
@@ -227,10 +227,10 @@ cdef class AbstractBitMap:
             for i in row_ints:
                 s = str(i)
                 if num_rows == 1:
-                    #no padding if all numbers fit on a single line
+                    # no padding if all numbers fit on a single line
                     line.append(s)
                 else:
-                    line.append(' '*(element_max_length-len(s)) + s)
+                    line.append(' ' * (element_max_length - len(s)) + s)
 
             if row_idx == 0:
                 prefix = head
@@ -239,12 +239,11 @@ cdef class AbstractBitMap:
             rows.append(prefix + ', '.join(line) + ',')
             row_idx += 1
             if skip_rows and not skipped and row_idx >= num_lines_if_skipping:
-                rows.append((' '* ((table_max_width + len(head)) // 2) )+  '...')
+                rows.append((' ' * ((table_max_width + len(head)) // 2)) + '...')
                 skipped = True
                 row_idx = num_rows - num_lines_if_skipping
 
-
-        rows[-1] = rows[-1].rstrip(',') #remove last comma
+        rows[-1] = rows[-1].rstrip(',')  # remove trailing comma from the last line
         return '\n'.join(rows) + tail
 
     def flip(self, uint64_t start, uint64_t end):

--- a/test.py
+++ b/test.py
@@ -7,7 +7,7 @@ import os
 import sys
 import pickle
 import re
-from hypothesis import given, settings, unlimited, Verbosity, errors
+from hypothesis import given, settings, unlimited, Verbosity, errors, HealthCheck
 import hypothesis.strategies as st
 import array
 import pyroaring
@@ -1354,6 +1354,40 @@ class PythonSetEquivalentTest(unittest.TestCase):
         b1.update(b2, b3)
 
         self.assertEqual(s1, set(b1))
+
+small_list_of_uin32 = st.lists(min_size=0, max_size=400, elements=uint32)
+large_list_of_uin32 = st.lists(min_size=600, max_size=1000, elements=uint32, unique=True)
+class StringTest(unittest.TestCase):
+
+    @given(bitmap_cls, small_list_of_uin32)
+    def test_small_list(self, cls, collection):
+        #test that repr for a small bitmap is equal to the original bitmap
+        bm = cls(collection)
+        self.assertEqual(bm, eval(repr(bm)))
+
+    @settings(suppress_health_check=HealthCheck.all(), max_shrinks=0)
+    @given(bitmap_cls, large_list_of_uin32)
+    def test_large_list(self, cls, collection):
+        # test that for a large bitmap the both the start and the end of the bitmap get printed
+
+        bm = cls(collection)
+        s = repr(bm)
+        nondigits = set(s) - set('0123456789\n.')
+        for i in nondigits:
+            s = s.replace(i, ' ')
+
+        small, large = s.split('...')
+        small_ints = [int(i) for i in small.split()]
+        large_ints = [int(i) for i in large.split()]
+
+        for i in small_ints:
+            self.assertTrue(i in bm)
+
+        for i in large_ints:
+            self.assertTrue(i in bm)
+
+        self.assertTrue(min(small_ints) == min(bm))
+        self.assertTrue(max(large_ints) == max(bm))
 
 
 class VersionTest(unittest.TestCase):

--- a/test.py
+++ b/test.py
@@ -1381,13 +1381,13 @@ class StringTest(unittest.TestCase):
         large_ints = [int(i) for i in large.split()]
 
         for i in small_ints:
-            self.assertTrue(i in bm)
+            self.assertIn(i, bm)
 
         for i in large_ints:
-            self.assertTrue(i in bm)
+            self.assertIn(i, bm)
 
-        self.assertTrue(min(small_ints) == min(bm))
-        self.assertTrue(max(large_ints) == max(bm))
+        self.assertEqual(min(small_ints), min(bm))
+        self.assertEqual(max(large_ints), max(bm))
 
 
 class VersionTest(unittest.TestCase):


### PR DESCRIPTION
When working with BitMaps in jupyter notebooks, it is easy to accidentally print out a huge string representation. 

For example, the very compact `BitMap(range(2**25))` has a string representation of more than 300MB. Any larger than that and jupyter tends to crash. This pull request suggests a way of truncating large BitMaps when converting to strings.

Empty BitMap gets printed.
```python
print(BitMap())
#BitMap([])

```

BitMaps that fit on one line get printed compactly.
```python
print(BitMap(range(10)))
# BitMap([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])

```

BitMaps that don't fit on one line get printed in aligned columns.
```python
print(BitMap(range(30)))
# BitMap([ 0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
#         20, 21, 22, 23, 24, 25, 26, 27, 28, 29])
```

```python
bm = BitMap(range(30))
bm.add(10**6)
print(bm)
# BitMap([      0,       1,       2,       3,       4,       5,       6,       7,
#               8,       9,      10,      11,      12,      13,      14,      15,
#              16,      17,      18,      19,      20,      21,      22,      23,
#              24,      25,      26,      27,      28,      29, 1000000])

```


BitMaps over some limit (currently 500 elements) get truncated. The start and end get printed while the skipped elements are represented by three dots. This also makes it illegal python, so `eval(repr(BitMap(range(1000))))` raises a SyntaxError and doesn't silently corrupt any data.

```python
bm = BitMap(range(1000))
print(bm)
# BitMap([  0,   1,   2,   3,   4,   5,   6,   7,   8,   9,  10,  11,  12,  13,  14,  15,
#          16,  17,  18,  19,  20,  21,  22,  23,  24,  25,  26,  27,  28,  29,  30,  31,
#          32,  33,  34,  35,  36,  37,  38,  39,  40,  41,  42,  43,  44,  45,  46,  47,
#          48,  49,  50,  51,  52,  53,  54,  55,  56,  57,  58,  59,  60,  61,  62,  63,
#          64,  65,  66,  67,  68,  69,  70,  71,  72,  73,  74,  75,  76,  77,  78,  79,
#                                             ...
#         928, 929, 930, 931, 932, 933, 934, 935, 936, 937, 938, 939, 940, 941, 942, 943,
#         944, 945, 946, 947, 948, 949, 950, 951, 952, 953, 954, 955, 956, 957, 958, 959,
#         960, 961, 962, 963, 964, 965, 966, 967, 968, 969, 970, 971, 972, 973, 974, 975,
#         976, 977, 978, 979, 980, 981, 982, 983, 984, 985, 986, 987, 988, 989, 990, 991,
#         992, 993, 994, 995, 996, 997, 998, 999])

```