### PR TITLE
Allow disabling --march with ARCHI=generic

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -90,7 +90,8 @@ else:
     else:
         compile_args.append('-O3')
     if 'ARCHI' in os.environ:
-        compile_args.extend(['-march=%s' % os.environ['ARCHI']])
+        if os.environ['ARCHI'] != "generic":
+            compile_args.extend(['-march=%s' % os.environ['ARCHI']])
     else:
         compile_args.append('-march=native')
 


### PR DESCRIPTION
There's no concept of generic march in compilers (documentation says this is because there is no generic CPU ABI so it would not make sense). Let's treat ARCHI=generic as not passing --march at all. Closes #50 