### PR TITLE
Upgrade hypothesis

### DIFF
--- a/test.py
+++ b/test.py
@@ -13,9 +13,6 @@ import array
 import pyroaring
 from pyroaring import BitMap, FrozenBitMap
 
-import hypothesis
-print(hypothesis.__version__)
-
 is_python2 = sys.version_info < (3, 0)
 
 try:  # Python2 compatibility

--- a/test.py
+++ b/test.py
@@ -37,6 +37,7 @@ except errors.InvalidArgument:
 uint18 = st.integers(min_value=0, max_value=2**18)
 uint32 = st.integers(min_value=0, max_value=2**32-1)
 uint64 = st.integers(min_value=0, max_value=2**64-1)
+large_uint64 = st.integers(min_value=2**32, max_value=2**64-1)
 integer = st.integers(min_value=0, max_value=2**31-1)
 
 range_max_size = 2**18
@@ -477,9 +478,8 @@ class RangeTest(Util):
         self.assertFalse(bm.contains_range(start, end))
         self.assertEqual(bm.intersection_cardinality(BitMap(range(start, end), copy_on_write=cow)), 0)
 
-    @given(hyp_collection, st.booleans(), uint64, uint64)
+    @given(hyp_collection, st.booleans(), large_uint64, large_uint64)
     def test_large_values(self, values, cow, start, end):
-        assume(start >= 2**32 and end >= 2**32)
         bm = BitMap(values, copy_on_write=cow)
         original = BitMap(bm)
         bm.add_range(start, end)

--- a/test.py
+++ b/test.py
@@ -114,7 +114,7 @@ class Util(unittest.TestCase):
 class BasicTest(Util):
 
     @given(hyp_collection, st.booleans())
-    @settings()
+    @settings(deadline=None)
     def test_basic(self, values, cow):
         bitmap = BitMap(copy_on_write=cow)
         self.assertEqual(bitmap.copy_on_write, cow)

--- a/test.py
+++ b/test.py
@@ -320,7 +320,7 @@ class SelectRankTest(Util):
         assume(len(values) > 0)
         bitmap = cls(values, copy_on_write=cow)
         try:
-            expected = next(i for i in values if i >= other_value)
+            expected = next(i for i in sorted(values) if i >= other_value)
             self.assertEqual(bitmap.next_set_bit(other_value), expected)
         except StopIteration:
             with self.assertRaises(ValueError):

--- a/test.py
+++ b/test.py
@@ -7,7 +7,7 @@ import os
 import sys
 import pickle
 import re
-from hypothesis import given, settings, Verbosity, errors, HealthCheck
+from hypothesis import given, settings, Verbosity, errors, HealthCheck, assume
 import hypothesis.strategies as st
 import array
 import pyroaring
@@ -116,7 +116,7 @@ class Util(unittest.TestCase):
 class BasicTest(Util):
 
     @given(hyp_collection, st.booleans())
-    @settings(deadline=None)
+    @settings()
     def test_basic(self, values, cow):
         bitmap = BitMap(copy_on_write=cow)
         self.assertEqual(bitmap.copy_on_write, cow)
@@ -156,7 +156,7 @@ class BasicTest(Util):
 
     @given(bitmap_cls, bitmap_cls, hyp_collection, hyp_collection, st.booleans())
     def test_bitmap_unequality(self, cls1, cls2, values1, values2, cow):
-        st.assume(set(values1) != set(values2))
+        assume(set(values1) != set(values2))
         bitmap1 = cls1(values1, copy_on_write=cow)
         bitmap2 = cls2(values2, copy_on_write=cow)
         self.assertNotEqual(bitmap1, bitmap2)
@@ -263,19 +263,19 @@ class SelectRankTest(Util):
 
     @given(bitmap_cls, hyp_collection, slice_arg(2**12), slice_arg(2**12), slice_arg(2**5), st.booleans())
     def test_slice_select_non_empty(self, cls, values, start, stop, step, cow):
-        st.assume(step != 0)
-        st.assume(len(range(start, stop, step)) > 0)
+        assume(step != 0)
+        assume(len(range(start, stop, step)) > 0)
         self.check_slice(cls, values, start, stop, step, cow)
 
     @given(bitmap_cls, hyp_collection, slice_arg(2**12), slice_arg(2**12), slice_arg(2**5), st.booleans())
     def test_slice_select_empty(self, cls, values, start, stop, step, cow):
-        st.assume(step != 0)
-        st.assume(len(range(start, stop, step)) == 0)
+        assume(step != 0)
+        assume(len(range(start, stop, step)) == 0)
         self.check_slice(cls, values, start, stop, step, cow)
 
     @given(bitmap_cls, hyp_collection, slice_arg(2**12) | st.none(), slice_arg(2**12) | st.none(), slice_arg(2**5) | st.none(), st.booleans())
     def test_slice_select_none(self, cls, values, start, stop, step, cow):
-        st.assume(step != 0)
+        assume(step != 0)
         self.check_slice(cls, values, start, stop, step, cow)
 
     @given(bitmap_cls, hyp_collection, st.booleans())
@@ -293,7 +293,7 @@ class SelectRankTest(Util):
 
     @given(bitmap_cls, hyp_collection, st.booleans())
     def test_min(self, cls, values, cow):
-        st.assume(len(values) > 0)
+        assume(len(values) > 0)
         bitmap = cls(values, copy_on_write=cow)
         self.assertEqual(bitmap.min(), min(values))
 
@@ -305,7 +305,7 @@ class SelectRankTest(Util):
 
     @given(bitmap_cls, hyp_collection, st.booleans())
     def test_max(self, cls, values, cow):
-        st.assume(len(values) > 0)
+        assume(len(values) > 0)
         bitmap = cls(values, copy_on_write=cow)
         self.assertEqual(bitmap.max(), max(values))
 
@@ -317,7 +317,7 @@ class SelectRankTest(Util):
 
     @given(bitmap_cls, hyp_collection, uint32, st.booleans())
     def test_next_set_bit(self, cls, values, other_value, cow):
-        st.assume(len(values) > 0)
+        assume(len(values) > 0)
         bitmap = cls(values, copy_on_write=cow)
         try:
             expected = next(i for i in values if i >= other_value)
@@ -434,7 +434,7 @@ class RangeTest(Util):
 
     @given(bitmap_cls, st.booleans(), uint32, uint32)
     def test_contains_range(self, cls, cow, start, end):
-        st.assume(start < end)
+        assume(start < end)
         self.assertTrue(cls(range(start, end)).contains_range(start, end))
         self.assertTrue(cls(range(start, end)).contains_range(start, end-1))
         self.assertFalse(cls(range(start, end-1)).contains_range(start, end))
@@ -455,7 +455,7 @@ class RangeTest(Util):
 
     @given(hyp_collection, st.booleans(), uint32, uint32)
     def test_add_remove_range(self, values, cow, start, end):
-        st.assume(start < end)
+        assume(start < end)
         bm = BitMap(values, copy_on_write=cow)
         # Empty range
         original = BitMap(bm)
@@ -479,7 +479,7 @@ class RangeTest(Util):
 
     @given(hyp_collection, st.booleans(), uint64, uint64)
     def test_large_values(self, values, cow, start, end):
-        st.assume(start >= 2**32 and end >= 2**32)
+        assume(start >= 2**32 and end >= 2**32)
         bm = BitMap(values, copy_on_write=cow)
         original = BitMap(bm)
         bm.add_range(start, end)
@@ -517,7 +517,7 @@ class CardinalityTest(Util):
 
     @given(bitmap_cls, bitmap_cls, hyp_collection, hyp_collection, st.booleans())
     def test_jaccard_index(self, cls1, cls2, values1, values2, cow):
-        st.assume(len(values1) > 0 or len(values2) > 0)
+        assume(len(values1) > 0 or len(values2) > 0)
         self.bitmap1 = cls1(values1, copy_on_write=cow)
         self.bitmap2 = cls2(values2, copy_on_write=cow)
         real_value = float(len(self.bitmap1 & self.bitmap2)) / \
@@ -689,7 +689,7 @@ class FlipTest(Util):
 
     @given(bitmap_cls, hyp_collection, integer, integer, st.booleans())
     def test_flip_empty(self, cls, values, start, end, cow):
-        st.assume(start >= end)
+        assume(start >= end)
         bm_before = cls(values, copy_on_write=cow)
         bm_copy = cls(bm_before)
         bm_after = bm_before.flip(start, end)
@@ -698,7 +698,7 @@ class FlipTest(Util):
 
     @given(bitmap_cls, hyp_collection, integer, integer, st.booleans())
     def test_flip(self, cls, values, start, end, cow):
-        st.assume(start < end)
+        assume(start < end)
         bm_before = cls(values, copy_on_write=cow)
         bm_copy = cls(bm_before)
         bm_after = bm_before.flip(start, end)
@@ -707,7 +707,7 @@ class FlipTest(Util):
 
     @given(hyp_collection, integer, integer, st.booleans())
     def test_flip_inplace_empty(self, values, start, end, cow):
-        st.assume(start >= end)
+        assume(start >= end)
         bm_before = BitMap(values, copy_on_write=cow)
         bm_after = BitMap(bm_before)
         bm_after.flip_inplace(start, end)
@@ -715,7 +715,7 @@ class FlipTest(Util):
 
     @given(hyp_collection, integer, integer, st.booleans())
     def test_flip_inplace(self, values, start, end, cow):
-        st.assume(start < end)
+        assume(start < end)
         bm_before = BitMap(values, copy_on_write=cow)
         bm_after = BitMap(bm_before)
         bm_after.flip_inplace(start, end)
@@ -857,7 +857,7 @@ class FrozenTest(unittest.TestCase):
         """This test as a non null (but extremly low) probability to fail."""
         bitmap1 = FrozenBitMap(values1)
         bitmap2 = FrozenBitMap(values2)
-        st.assume(bitmap1 != bitmap2)
+        assume(bitmap1 != bitmap2)
         self.assertNotEqual(hash(bitmap1), hash(bitmap2))
 
     @given(hyp_collection)

--- a/test.py
+++ b/test.py
@@ -7,7 +7,7 @@ import os
 import sys
 import pickle
 import re
-from hypothesis import given, settings, unlimited, Verbosity, errors, HealthCheck
+from hypothesis import given, settings, Verbosity, errors, HealthCheck
 import hypothesis.strategies as st
 import array
 import pyroaring
@@ -21,7 +21,7 @@ except NameError:
     pass
 
 settings.register_profile("ci", settings(
-    max_examples=100, deadline=None, timeout=unlimited))
+    max_examples=100, deadline=None))
 settings.register_profile("dev", settings(max_examples=10, deadline=None))
 settings.register_profile("debug", settings(
     max_examples=10, verbosity=Verbosity.verbose, deadline=None))

--- a/test.py
+++ b/test.py
@@ -13,6 +13,9 @@ import array
 import pyroaring
 from pyroaring import BitMap, FrozenBitMap
 
+import hypothesis
+print(hypothesis.__version__)
+
 is_python2 = sys.version_info < (3, 0)
 
 try:  # Python2 compatibility
@@ -1410,7 +1413,7 @@ class StringTest(unittest.TestCase):
         bm = cls(collection)
         self.assertEqual(bm, eval(repr(bm)))
 
-    @settings(suppress_health_check=HealthCheck.all(), max_shrinks=0)
+    @settings(suppress_health_check=HealthCheck.all())
     @given(bitmap_cls, large_list_of_uin32)
     def test_large_list(self, cls, collection):
         # test that for a large bitmap the both the start and the end of the bitmap get printed


### PR DESCRIPTION
As mentioned in #60, hypothesis has made a number of backwards-incompatible changes over time. 
I tried running the test suite with most minor versions from hypothesis 3.57 up to 5.29 and fixed any errors/warnings/failures that came up along the way.

Note: this PR does not change the requirements.txt as I'm not sure how that is generated for this project.
