### PR TITLE
The -march=native flag added systematically is a bad idea.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -161,6 +161,20 @@ Example of use:
     DEBUG=1 ARCHI=x86-64 python setup.py build_ext
 
 
+Optimizing the builds for your machine (x64)
+---------
+
+For recent Intel and AMD (x64) processors under Linux, you may get better performance by requesting that
+CRoaring be built for your machine, specifically, when building from source.
+Be mindful that when doing so, the generated binary may only run on your machine.
+
+
+.. code:: bash
+
+    ARCHI=native pip install pyroaring  --no-binary :all:
+
+This approach may not work under macOS.
+
 Benchmark
 ---------
 

--- a/setup.py
+++ b/setup.py
@@ -92,8 +92,13 @@ else:
     if 'ARCHI' in os.environ:
         if os.environ['ARCHI'] != "generic":
             compile_args.extend(['-march=%s' % os.environ['ARCHI']])
-    else:
-        compile_args.append('-march=native')
+    # The '-march=native' flag is not universally allowed. In particular, it
+    # will systematically fail on aarch64 systems (like the new Apple M1 systems). It
+    # also creates troubles under macOS with pip installs and requires ugly workarounds.
+    # The best way to handle people who want to use -march=native is to ask them
+    # to pass ARCHI=native to their build process.
+    #else:
+    #    compile_args.append('-march=native')
 
 filename = os.path.join(PKG_DIR, 'pyroaring.%s' % ext)
 pyroaring = Extension('pyroaring',


### PR DESCRIPTION
I do not think one should systematically build with -march=native. Under non-x64 systems, this flag is not going to ever be recognized in my experience. It breaks the macOS installs, it makes pip fail (and requires the user to disable it).

It is just better to document how people who need it can invoke it.