### PR TITLE
Support "in place" operations on `FrozenBitMaps`

### DIFF
--- a/pyroaring/abstract_bitmap.pxi
+++ b/pyroaring/abstract_bitmap.pxi
@@ -443,34 +443,17 @@ cdef class AbstractBitMap:
         cdef croaring.roaring_bitmap_t *r = func(self._c_bitmap, other._c_bitmap)
         return self.from_ptr(r)
 
-    cdef binary_iop(self, AbstractBitMap other, (void)func(croaring.roaring_bitmap_t*, const croaring.roaring_bitmap_t*)):
-        self.__check_compatibility(other)
-        func(self._c_bitmap, other._c_bitmap)
-        return self
-
     def __or__(self, other):
         return (<AbstractBitMap>self).binary_op(<AbstractBitMap?>other, croaring.roaring_bitmap_or)
-
-    def __ior__(self, other):
-        return (<AbstractBitMap>self).binary_iop(<AbstractBitMap?>other, croaring.roaring_bitmap_or_inplace)
 
     def __and__(self, other):
         return (<AbstractBitMap>self).binary_op(<AbstractBitMap?>other, croaring.roaring_bitmap_and)
 
-    def __iand__(self, other):
-        return (<AbstractBitMap>self).binary_iop(<AbstractBitMap?>other, croaring.roaring_bitmap_and_inplace)
-
     def __xor__(self, other):
         return (<AbstractBitMap>self).binary_op(<AbstractBitMap?>other, croaring.roaring_bitmap_xor)
 
-    def __ixor__(self, other):
-        return (<AbstractBitMap>self).binary_iop(<AbstractBitMap?>other, croaring.roaring_bitmap_xor_inplace)
-
     def __sub__(self, other):
         return (<AbstractBitMap>self).binary_op(<AbstractBitMap?>other, croaring.roaring_bitmap_andnot)
-
-    def __isub__(self, other):
-        return (<AbstractBitMap>self).binary_iop(<AbstractBitMap?>other, croaring.roaring_bitmap_andnot_inplace)
 
     def union_cardinality(self, AbstractBitMap other):
         """

--- a/pyroaring/bitmap.pxi
+++ b/pyroaring/bitmap.pxi
@@ -106,6 +106,23 @@ cdef class BitMap(AbstractBitMap):
         if not test:
             raise KeyError(value)
 
+    cdef binary_iop(self, AbstractBitMap other, (void)func(croaring.roaring_bitmap_t*, const croaring.roaring_bitmap_t*)):
+        self.__check_compatibility(other)
+        func(self._c_bitmap, other._c_bitmap)
+        return self
+
+    def __ior__(self, other):
+        return (<BitMap>self).binary_iop(<AbstractBitMap?>other, croaring.roaring_bitmap_or_inplace)
+
+    def __iand__(self, other):
+        return (<BitMap>self).binary_iop(<AbstractBitMap?>other, croaring.roaring_bitmap_and_inplace)
+
+    def __ixor__(self, other):
+        return (<BitMap>self).binary_iop(<AbstractBitMap?>other, croaring.roaring_bitmap_xor_inplace)
+
+    def __isub__(self, other):
+        return (<BitMap>self).binary_iop(<AbstractBitMap?>other, croaring.roaring_bitmap_andnot_inplace)
+
     def intersection_update(self, *all_values): # FIXME could be more efficient
         """
         Update the bitmap by taking its intersection with the given values.

--- a/pyroaring/frozen_bitmap.pxi
+++ b/pyroaring/frozen_bitmap.pxi
@@ -1,13 +1,2 @@
 cdef class FrozenBitMap(AbstractBitMap):
-
-    def __ior__(self, other):
-        return self.__or__(other)
-
-    def __iand__(self, other):
-        return self.__and__(other)
-
-    def __ixor__(self, other):
-        return self.__xor__(other)
-
-    def __isub__(self, other):
-        return self.__sub__(other)
+    pass

--- a/pyroaring/frozen_bitmap.pxi
+++ b/pyroaring/frozen_bitmap.pxi
@@ -1,17 +1,13 @@
 cdef class FrozenBitMap(AbstractBitMap):
 
     def __ior__(self, other):
-        '''Unsupported method.'''
-        raise TypeError('Cannot modify a %s.' % self.__class__.__name__)
+        return self.__or__(other)
 
     def __iand__(self, other):
-        '''Unsupported method.'''
-        raise TypeError('Cannot modify a %s.' % self.__class__.__name__)
+        return self.__and__(other)
 
     def __ixor__(self, other):
-        '''Unsupported method.'''
-        raise TypeError('Cannot modify a %s.' % self.__class__.__name__)
+        return self.__xor__(other)
 
     def __isub__(self, other):
-        '''Unsupported method.'''
-        raise TypeError('Cannot modify a %s.' % self.__class__.__name__)
+        return self.__sub__(other)


### PR DESCRIPTION
These are "in place" in terms of the variable, but not the instance. This matches the behaviour of the built-in `frozenset` type.

Fixes https://github.com/Ezibenroc/PyRoaringBitMap/issues/75