### PR TITLE
Pin Cython to version <3.0.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,7 @@ setup(
     version=VERSION,
     description='Fast and lightweight set for unsigned 32 bits integers.',
     long_description=long_description,
-    setup_requires=['cython'],
+    setup_requires=['cython<3.0.0'],
     url='https://github.com/Ezibenroc/PyRoaringBitMap',
     author='Tom Cornebize',
     author_email='tom.cornebize@gmail.com',


### PR DESCRIPTION
Cython 3.0.0 was released on July 17th. This new version is causing our build to fail.
This pull request fixes #93.
This is a temporary fix, waiting for #94 to be merged.