### PR TITLE
Cython3 compatibility

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,4 +28,4 @@ jobs:
               env:
                 HYPOTHESIS_PROFILE: ci
               run: |
-                tox -e test
+                tox

--- a/pyroaring/bitmap.pxi
+++ b/pyroaring/bitmap.pxi
@@ -106,21 +106,24 @@ cdef class BitMap(AbstractBitMap):
         if not test:
             raise KeyError(value)
 
-    cdef binary_iop(self, AbstractBitMap other, (void)func(croaring.roaring_bitmap_t*, const croaring.roaring_bitmap_t*)):
-        self.__check_compatibility(other)
+    cdef binary_iop(self, AbstractBitMap other, (void)func(croaring.roaring_bitmap_t*, const croaring.roaring_bitmap_t*) noexcept) noexcept:
         func(self._c_bitmap, other._c_bitmap)
         return self
 
     def __ior__(self, other):
+        self._check_compatibility(other)
         return (<BitMap>self).binary_iop(<AbstractBitMap?>other, croaring.roaring_bitmap_or_inplace)
 
     def __iand__(self, other):
+        self._check_compatibility(other)
         return (<BitMap>self).binary_iop(<AbstractBitMap?>other, croaring.roaring_bitmap_and_inplace)
 
     def __ixor__(self, other):
+        self._check_compatibility(other)
         return (<BitMap>self).binary_iop(<AbstractBitMap?>other, croaring.roaring_bitmap_xor_inplace)
 
     def __isub__(self, other):
+        self._check_compatibility(other)
         return (<BitMap>self).binary_iop(<AbstractBitMap?>other, croaring.roaring_bitmap_andnot_inplace)
 
     def intersection_update(self, *all_values): # FIXME could be more efficient

--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,7 @@ setup(
     version=VERSION,
     description='Fast and lightweight set for unsigned 32 bits integers.',
     long_description=long_description,
-    setup_requires=['cython'],
+    setup_requires=['cython<3.0.0'],
     url='https://github.com/Ezibenroc/PyRoaringBitMap',
     author='Tom Cornebize',
     author_email='tom.cornebize@gmail.com',

--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,7 @@ setup(
     version=VERSION,
     description='Fast and lightweight set for unsigned 32 bits integers.',
     long_description=long_description,
-    setup_requires=['cython<3.0.0'],
+    setup_requires=['cython'],
     url='https://github.com/Ezibenroc/PyRoaringBitMap',
     author='Tom Cornebize',
     author_email='tom.cornebize@gmail.com',

--- a/tox.ini
+++ b/tox.ini
@@ -31,6 +31,7 @@ commands =
 deps =
 	hypothesis
 	wheel
+	build
 	twine
 skip_sdist = true
 skip_install = true
@@ -41,12 +42,9 @@ allowlist_externals =
 	mkdir
 commands =
 	# Clear our prebuilt wheels so we have a fresh directory
-    - mkdir wheel
-    - rm wheel/*
-    # Build the wheel into the cleaned directory
-	pip wheel . -w wheel
+	python -m build
 	# Install from the wheel in that directory
-	pip install --only-binary ":all:" --find-links=wheel --no-index pyroaring
+	pip install --only-binary ":all:" --find-links=dist --no-index pyroaring
 	python test.py
 	python cydoctest.py
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,25 @@
 [tox]
 envlist =
-	test
+	cython_pre3
+	cython3
 	test_wheel
 
 
-[testenv:test]
+[testenv:cython_pre3]
 deps =
 	hypothesis
+	cython<3.0.0
+passenv =
+	HYPOTHESIS_PROFILE
+commands =
+	python test.py
+	python cydoctest.py
+
+
+[testenv:cython3]
+deps =
+	hypothesis
+	cython>=3.0.2
 passenv =
 	HYPOTHESIS_PROFILE
 commands =
@@ -33,7 +46,7 @@ commands =
     # Build the wheel into the cleaned directory
 	pip wheel . -w wheel
 	# Install from the wheel in that directory
-	pip install --only-binary ":all:" --find-links=wheel pyroaring
+	pip install --only-binary ":all:" --find-links=wheel --no-index pyroaring
 	python test.py
 	python cydoctest.py
 


### PR DESCRIPTION
This makes the necessary changes for Cython 3 compatibility, while still working with Cython <3. This PR removes the need to use the `legacy_implicit_noexcept` directive.

I've also changed the way wheels are built for the test_wheels tox environment, now using `python -m build` to create them in an isolated environment. This is because I was running into the same test failures on MacOSX as my last PR - I'm not 100% sure if that's even a Cython only problem, or a combination of Cython + Tox + installation things. I'd investigate further into why this works, but I don't have access to an OSX environment. I'd expect most people will be using prebuilt wheels anyway, and the standard local source install test cases work without changes anyway.

