### PR TITLE
Tidy some tests up in order to update hypothesis

### DIFF
--- a/.github/workflows/buildwheels.yml
+++ b/.github/workflows/buildwheels.yml
@@ -53,8 +53,8 @@ jobs:
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.15.0
         env:
-          CIBW_TEST_REQUIRES: hypothesis==6.79.4
-          CIBW_TEST_COMMAND: "python {project}/test.py && python {project}/cydoctest.py"
+          CIBW_TEST_REQUIRES: hypothesis
+          CIBW_TEST_COMMAND: "python {project}/test.py -v && python {project}/cydoctest.py -v"
           CIBW_SKIP: "pp* cp36-*"
           CIBW_ARCHS: ${{ matrix.cibw_archs }}
           CIBW_TEST_SKIP: "*-win_arm64"

--- a/test.py
+++ b/test.py
@@ -3,6 +3,7 @@
 import unittest
 import random
 import functools
+import operator
 import os
 import sys
 import pickle
@@ -335,129 +336,74 @@ class SelectRankTest(Util):
 class BinaryOperationsTest(Util):
 
     @given(bitmap_cls, bitmap_cls, hyp_collection, hyp_collection, st.booleans())
-    def do_test_binary_op(self, op, cls1, cls2,  values1, values2, cow):
-        self.set1 = set(values1)
-        self.set2 = set(values2)
-        self.bitmap1 = cls1(values1, cow)
-        self.bitmap2 = cls2(values2, cow)
-        old_bitmap1 = cls1(self.bitmap1)
-        old_bitmap2 = cls2(self.bitmap2)
-        result_set = op(self.set1, self.set2)
-        result_bitmap = op(self.bitmap1, self.bitmap2)
-        self.assertEqual(self.bitmap1, old_bitmap1)
-        self.assertEqual(self.bitmap2, old_bitmap2)
-        self.compare_with_set(result_bitmap, result_set)
-        self.assertEqual(type(self.bitmap1), type(result_bitmap))
-
-    def test_or(self):
-        self.do_test_binary_op(lambda x, y: x | y)
-
-    def test_and(self):
-        self.do_test_binary_op(lambda x, y: x & y)
-
-    def test_xor(self):
-        self.do_test_binary_op(lambda x, y: x ^ y)
-
-    def test_sub(self):
-        self.do_test_binary_op(lambda x, y: x-y)
+    def test_binary_op(self, cls1, cls2,  values1, values2, cow):
+        for op in [operator.or_, operator.and_, operator.xor, operator.sub]:
+            self.set1 = set(values1)
+            self.set2 = set(values2)
+            self.bitmap1 = cls1(values1, cow)
+            self.bitmap2 = cls2(values2, cow)
+            old_bitmap1 = cls1(self.bitmap1)
+            old_bitmap2 = cls2(self.bitmap2)
+            result_set = op(self.set1, self.set2)
+            result_bitmap = op(self.bitmap1, self.bitmap2)
+            self.assertEqual(self.bitmap1, old_bitmap1)
+            self.assertEqual(self.bitmap2, old_bitmap2)
+            self.compare_with_set(result_bitmap, result_set)
+            self.assertEqual(type(self.bitmap1), type(result_bitmap))
 
     @given(bitmap_cls, hyp_collection, hyp_collection, st.booleans())
-    def do_test_binary_op_inplace(self, op, cls2, values1, values2, cow):
-        self.set1 = set(values1)
-        self.set2 = set(values2)
-        self.bitmap1 = BitMap(values1, cow)
-        original = self.bitmap1
-        self.bitmap2 = cls2(values2, cow)
-        old_bitmap2 = cls2(self.bitmap2)
-        op(self.set1, self.set2)
-        op(self.bitmap1, self.bitmap2)
-        self.assertIs(original, self.bitmap1)
-        self.assertEqual(self.bitmap2, old_bitmap2)
-        self.compare_with_set(self.bitmap1, self.set1)
+    def test_binary_op_inplace(self, cls2, values1, values2, cow):
+        for op in [operator.ior, operator.iand, operator.ixor, operator.isub]:
+            self.set1 = set(values1)
+            self.set2 = set(values2)
+            self.bitmap1 = BitMap(values1, cow)
+            original = self.bitmap1
+            self.bitmap2 = cls2(values2, cow)
+            old_bitmap2 = cls2(self.bitmap2)
+            op(self.set1, self.set2)
+            op(self.bitmap1, self.bitmap2)
+            self.assertIs(original, self.bitmap1)
+            self.assertEqual(self.bitmap2, old_bitmap2)
+            self.compare_with_set(self.bitmap1, self.set1)
 
-    def test_or_inplace(self):
-        self.do_test_binary_op_inplace(lambda x, y: x.__ior__(y))
-
-    def test_and_inplace(self):
-        self.do_test_binary_op_inplace(lambda x, y: x.__iand__(y))
-
-    def test_xor_inplace(self):
-        self.do_test_binary_op_inplace(lambda x, y: x.__ixor__(y))
-
-    def test_sub_inplace(self):
-        self.do_test_binary_op_inplace(lambda x, y: x.__isub__(y))
 
     @given(bitmap_cls, hyp_collection, hyp_collection, st.booleans())
-    def do_test_binary_op_inplace_frozen(self, op, cls2, values1, values2, cow):
-        self.set1 = frozenset(values1)
-        self.set2 = frozenset(values2)
+    def test_binary_op_inplace_frozen(self, cls2, values1, values2, cow):
+        for op in [operator.ior, operator.iand, operator.ixor, operator.isub]:
+            self.set1 = frozenset(values1)
+            self.set2 = frozenset(values2)
 
-        self.bitmap1 = FrozenBitMap(values1, cow)
-        old_bitmap1 = FrozenBitMap(self.bitmap1)
-        self.bitmap2 = cls2(values2, cow)
-        old_bitmap2 = cls2(self.bitmap2)
+            self.bitmap1 = FrozenBitMap(values1, cow)
+            old_bitmap1 = FrozenBitMap(self.bitmap1)
+            self.bitmap2 = cls2(values2, cow)
+            old_bitmap2 = cls2(self.bitmap2)
 
-        new_set = op(self.set1, self.set2)
-        new_bitmap = op(self.bitmap1, self.bitmap2)
+            new_set = op(self.set1, self.set2)
+            new_bitmap = op(self.bitmap1, self.bitmap2)
 
-        self.assertEqual(self.bitmap1, old_bitmap1)
-        self.assertEqual(self.bitmap2, old_bitmap2)
+            self.assertEqual(self.bitmap1, old_bitmap1)
+            self.assertEqual(self.bitmap2, old_bitmap2)
 
-        self.compare_with_set(new_bitmap, new_set)
-
-    def test_or_inplace_frozen(self):
-        def op(x, y):
-            x |= y
-            return x
-        self.do_test_binary_op_inplace_frozen(op)
-
-    def test_and_inplace_frozen(self):
-        def op(x, y):
-            x &= y
-            return x
-        self.do_test_binary_op_inplace_frozen(op)
-
-    def test_xor_inplace_frozen(self):
-        def op(x, y):
-            x ^= y
-            return x
-        self.do_test_binary_op_inplace_frozen(op)
-
-    def test_sub_inplace_frozen(self):
-        def op(x, y):
-            x -= y
-            return x
-        self.do_test_binary_op_inplace_frozen(op)
+            self.compare_with_set(new_bitmap, new_set)
 
 
 class ComparisonTest(Util):
 
     @given(bitmap_cls, bitmap_cls, hyp_collection, hyp_collection, st.booleans())
-    def do_test(self, op, cls1, cls2, values1, values2, cow):
-        self.set1 = set(values1)
-        self.set2 = set(values2)
-        self.bitmap1 = cls1(values1, copy_on_write=cow)
-        self.bitmap2 = cls2(values2, copy_on_write=cow)
-        self.assertEqual(op(self.bitmap1, self.bitmap1),
-                         op(self.set1, self.set1))
-        self.assertEqual(op(self.bitmap1, self.bitmap2),
-                         op(self.set1, self.set2))
-        self.assertEqual(op(self.bitmap1 | self.bitmap2, self.bitmap2),
-                         op(self.set1 | self.set2, self.set2))
-        self.assertEqual(op(self.set1, self.set1 | self.set2),
-                         op(self.set1, self.set1 | self.set2))
-
-    def test_le(self):
-        self.do_test(lambda x, y: x <= y)
-
-    def test_ge(self):
-        self.do_test(lambda x, y: x >= y)
-
-    def test_lt(self):
-        self.do_test(lambda x, y: x < y)
-
-    def test_gt(self):
-        self.do_test(lambda x, y: x > y)
+    def test_comparison(self, cls1, cls2, values1, values2, cow):
+        for op in [operator.le, operator.ge, operator.lt, operator.gt]:
+            self.set1 = set(values1)
+            self.set2 = set(values2)
+            self.bitmap1 = cls1(values1, copy_on_write=cow)
+            self.bitmap2 = cls2(values2, copy_on_write=cow)
+            self.assertEqual(op(self.bitmap1, self.bitmap1),
+                             op(self.set1, self.set1))
+            self.assertEqual(op(self.bitmap1, self.bitmap2),
+                             op(self.set1, self.set2))
+            self.assertEqual(op(self.bitmap1 | self.bitmap2, self.bitmap2),
+                             op(self.set1 | self.set2, self.set2))
+            self.assertEqual(op(self.set1, self.set1 | self.set2),
+                             op(self.set1, self.set1 | self.set2))
 
     @given(bitmap_cls, bitmap_cls, hyp_collection, hyp_collection, st.booleans())
     def test_intersect(self, cls1, cls2, values1, values2, cow):
@@ -532,28 +478,19 @@ class RangeTest(Util):
 class CardinalityTest(Util):
 
     @given(bitmap_cls, bitmap_cls, hyp_collection, hyp_collection, st.booleans())
-    def do_test_cardinality(self, real_op, estimated_op, cls1, cls2, values1, values2, cow):
-        self.bitmap1 = cls1(values1, copy_on_write=cow)
-        self.bitmap2 = cls2(values2, copy_on_write=cow)
-        real_value = real_op(self.bitmap1, self.bitmap2)
-        estimated_value = estimated_op(self.bitmap1, self.bitmap2)
-        self.assertEqual(real_value, estimated_value)
+    def test_cardinality(self, cls1, cls2, values1, values2, cow):
 
-    def test_or_card(self):
-        self.do_test_cardinality(lambda x, y: len(
-            x | y), lambda x, y: x.union_cardinality(y))
-
-    def test_and_card(self):
-        self.do_test_cardinality(lambda x, y: len(
-            x & y), lambda x, y: x.intersection_cardinality(y))
-
-    def test_andnot_card(self):
-        self.do_test_cardinality(lambda x, y: len(
-            x-y), lambda x, y: x.difference_cardinality(y))
-
-    def test_xor_card(self):
-        self.do_test_cardinality(lambda x, y: len(
-            x ^ y), lambda x, y: x.symmetric_difference_cardinality(y))
+        for real_op, estimated_op in [
+            (operator.or_, cls1.union_cardinality),
+            (operator.and_, cls1.intersection_cardinality),
+            (operator.sub, cls1.difference_cardinality),
+            (operator.xor, cls1.symmetric_difference_cardinality)
+        ]:
+            self.bitmap1 = cls1(values1, copy_on_write=cow)
+            self.bitmap2 = cls2(values2, copy_on_write=cow)
+            real_value = len(real_op(self.bitmap1, self.bitmap2))
+            estimated_value = estimated_op(self.bitmap1, self.bitmap2)
+            self.assertEqual(real_value, estimated_value)
 
     @given(bitmap_cls, bitmap_cls, hyp_collection, hyp_collection, st.booleans())
     def test_jaccard_index(self, cls1, cls2, values1, values2, cow):

--- a/tox.ini
+++ b/tox.ini
@@ -5,31 +5,36 @@ envlist =
 	test_wheel
 
 
+[testenv]
+setenv =
+    PYTHONFAULTHANDLER=1
+
+
 [testenv:cython_pre3]
 deps =
-	hypothesis<=6.83.0
+	hypothesis
 	cython<3.0.0
 passenv =
 	HYPOTHESIS_PROFILE
 commands =
-	python test.py
+	python test.py -v
 	python cydoctest.py
 
 
 [testenv:cython3]
 deps =
-	hypothesis<=6.83.0
+	hypothesis
 	cython>=3.0.2
 passenv =
 	HYPOTHESIS_PROFILE
 commands =
-	python test.py
+	python test.py -v
 	python cydoctest.py
 
 
 [testenv:test_wheel]
 deps =
-	hypothesis<=6.83.0
+	hypothesis
 	wheel
 	build
 	twine
@@ -45,7 +50,7 @@ commands =
 	python -m build
 	# Install from the wheel in that directory
 	pip install --only-binary ":all:" --find-links=dist --no-index pyroaring
-	python test.py
+	python test.py -v
 	python cydoctest.py
 
 


### PR DESCRIPTION
While trying to get #102 working I noticed that an intermittent segfault happening that was unclear on inspecting the logs. While investigating it seemed easy to update the test reporting and remove the upper bound pin on hypothesis, so here we are.

This PR refactors the test cases to make more recent hypothesis happy, and makes sure that all individual test cases being run are reported so even segfaults can be inspected.