### PR TITLE
Drop support for testing on Python 2

### DIFF
--- a/test.py
+++ b/test.py
@@ -14,12 +14,6 @@ import array
 import pyroaring
 from pyroaring import BitMap, FrozenBitMap
 
-is_python2 = sys.version_info < (3, 0)
-
-try:  # Python2 compatibility
-    range = xrange
-except NameError:
-    pass
 
 settings.register_profile("ci", settings(
     max_examples=100, deadline=None))
@@ -537,7 +531,6 @@ class ManyOperationsTest(Util):
         self.assertEqual(expected_result, self.initial_bitmap)
         self.assertEqual(type(expected_result), type(self.initial_bitmap))
 
-    @unittest.skipIf(is_python2, 'https://github.com/Ezibenroc/PyRoaringBitMap/pull/38#issuecomment-418262391')
     @given(bitmap_cls, st.data(), hyp_many_collections, st.booleans())
     def test_union(self, cls, data, all_values, cow):
         classes = [data.draw(bitmap_cls) for _ in range(len(all_values))]
@@ -548,7 +541,6 @@ class ManyOperationsTest(Util):
             lambda x, y: x | y, self.all_bitmaps)
         self.assertEqual(expected_result, result)
 
-    @unittest.skipIf(is_python2, 'https://github.com/Ezibenroc/PyRoaringBitMap/pull/38#issuecomment-418262391')
     @given(bitmap_cls, st.data(), hyp_many_collections, st.booleans())
     def test_intersection(self, cls, data, all_values, cow):
         classes = [data.draw(bitmap_cls) for _ in range(len(all_values))]
@@ -559,7 +551,6 @@ class ManyOperationsTest(Util):
             lambda x, y: x & y, self.all_bitmaps)
         self.assertEqual(expected_result, result)
 
-    @unittest.skipIf(is_python2, 'https://github.com/Ezibenroc/PyRoaringBitMap/pull/38#issuecomment-418262391')
     @given(bitmap_cls, st.data(), hyp_many_collections, st.booleans())
     def test_difference(self, cls, data, all_values, cow):
         classes = [data.draw(bitmap_cls) for _ in range(len(all_values))]


### PR DESCRIPTION
This seems to have mostly gone away a while back, however some stuff remained (unclear how working that stuff was). I'm about to add typing annotations and that'll be much easier if we don't need to support Python 2 at all.