### PR TITLE
Fix an invalid test which wasn't checking what it seemed to check

### DIFF
--- a/test.py
+++ b/test.py
@@ -206,8 +206,10 @@ class BasicTest(Util):
     def test_wrong_constructor_values(self, cls):
         with self.assertRaises(TypeError):  # this should fire a type error!
             cls([3, 'bla', 3, 42])
-        with self.assertRaises(ValueError):
-            cls(range(0, 10, 0))
+
+        bad_range = range(-3, 0)
+        with self.assertRaises(OverflowError):
+            cls(bad_range)
 
     @given(bitmap_cls, hyp_collection, st.booleans())
     def test_to_array(self, cls, values, cow):


### PR DESCRIPTION
`range(0, 10, 0)` raises a `ValueError` on its own -- so there was no actual call to the __init__ here. Using a different range which is itself fine but not valid in a BitMap fixes that. Building the range outside the assertion context block should avoid a similar error creeping in in future.

Note: I'm actually not sure what case this was trying to catch previously as I can't see a codepath which would raise a `ValueError` from the `__init__`. Consequently the fix proposed here may not be correct.