### PR TITLE
Restrict Cython version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -88,7 +88,7 @@ setup(
     version=VERSION,
     description='Library for handling efficiently sorted integer sets.',
     long_description=long_description,
-    setup_requires=['cython>=3.0.2'],
+    setup_requires=['cython>=3.0.2,<3.1.0'],
     url='https://github.com/Ezibenroc/PyRoaringBitMap',
     author='Tom Cornebize',
     author_email='tom.cornebize@gmail.com',

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@ setenv =
 deps =
 	hypothesis
     pytest
-	cython>=3.0.2
+	cython>=3.0.2,<3.1.0
 passenv =
 	HYPOTHESIS_PROFILE
 	ROARING_BITSIZE


### PR DESCRIPTION
Cython version 3.1 introduces a bug (for instance [this test failing with the latest commit](https://github.com/Ezibenroc/PyRoaringBitMap/actions/runs/15786877816) whereas it passed successfully one month ago).

To reproduce:

```
from pyroaring import BitMap
bm = BitMap(range(1000))
repr(bm)
```