### PR TITLE
Fix floating point slice indices in _string_rep in Cython 3.1.*

### DIFF
--- a/pyroaring/abstract_bitmap.pxi
+++ b/pyroaring/abstract_bitmap.pxi
@@ -60,10 +60,7 @@ def _string_rep(bm):
 
     num_columns = table_max_width // column_width
 
-    num_rows = len(bm) / float(num_columns)
-    if not num_rows.is_integer():
-        num_rows += 1
-    num_rows = int(num_rows)
+    num_rows = (len(bm) + num_columns - 1) // num_columns
     rows = []
     row_idx = 0
     skipped = False

--- a/setup.py
+++ b/setup.py
@@ -88,7 +88,7 @@ setup(
     version=VERSION,
     description='Library for handling efficiently sorted integer sets.',
     long_description=long_description,
-    setup_requires=['cython>=3.0.2,<3.1.0'],
+    setup_requires=['cython>=3.0.2'],
     url='https://github.com/Ezibenroc/PyRoaringBitMap',
     author='Tom Cornebize',
     author_email='tom.cornebize@gmail.com',

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@ setenv =
 deps =
 	hypothesis
     pytest
-	cython>=3.0.2,<3.1.0
+	cython>=3.0.2
 passenv =
 	HYPOTHESIS_PROFILE
 	ROARING_BITSIZE


### PR DESCRIPTION
Tracked down the issue preventing `TestString::test_large_list` from passing when compiling with Cython 3.1.*.

Specifically, the issue came down to the calculated `num_rows` in `_string_rep` staying floating point instead of getting cast to an int.

I'm not sure whether Cython 3.1.* broke variable shadowing, or optimized out `num_rows = int(num_rows)`... or something else. But in any case, we can avoid the floating point operations (and float-typed variable) by switching _string_rep to use the following formula for calculating the celing of integer division:

`ceil(x / y) = (x + y - 1) // y`

Since all tests now pass on Cython 3.1.*, this change also removes the upper constraints on Cython.

Fixes: #134