### PR TITLE
Introduce a property to get the pointer to the underlying bitmap

### DIFF
--- a/pyroaring/__init__.pyi
+++ b/pyroaring/__init__.pyi
@@ -33,6 +33,10 @@ class AbstractBitMap:
         ...
 
     @property
+    def raw_pointer(self) -> int:
+        ...
+
+    @property
     def copy_on_write(self) -> bool:
         ...
 
@@ -254,6 +258,10 @@ class BitMap(AbstractBitMap):
 
 class AbstractBitMap64:
     def __init__(self, values: Iterable[int] | None = None, copy_on_write: bool = False, optimize: bool = True) -> None:
+        ...
+
+    @property
+    def raw_pointer(self) -> int:
         ...
 
     @property

--- a/pyroaring/abstract_bitmap.pxi
+++ b/pyroaring/abstract_bitmap.pxi
@@ -1,5 +1,5 @@
 cimport croaring
-from libc.stdint cimport uint32_t, uint64_t, int64_t
+from libc.stdint cimport uint32_t, uint64_t, uintptr_t, int64_t
 from libcpp cimport bool
 from libcpp.vector cimport vector
 from libc.stdlib cimport free, malloc
@@ -173,6 +173,26 @@ cdef class AbstractBitMap:
         bm = self.__class__.__new__(self.__class__, no_init=True)
         (<AbstractBitMap>bm)._c_bitmap = ptr
         return bm
+
+    @property
+    def raw_pointer(self):
+        """
+        The address of the underlying `roaring_bitmap_t`, as a Python int.
+
+        Intended for FFI interop, e.g. passing the bitmap to another
+        native extension via CFFI or ctypes without a copy.
+
+        Caveats (the caller is responsible for all of these):
+
+        - The pointer is owned by this Python object. It is only valid
+          while the object is alive; the caller must not pass it to
+          `roaring_bitmap_free`.
+
+        - Mutating the bitmap through this pointer on a `FrozenBitMap`
+          is undefined behaviour: it silently invalidates the cached
+          hash and breaks set/dict semantics.
+        """
+        return <uintptr_t>self._c_bitmap
 
     @property
     def copy_on_write(self):
@@ -879,6 +899,26 @@ cdef class AbstractBitMap64:
         bm = self.__class__.__new__(self.__class__, no_init=True)
         (<AbstractBitMap64>bm)._c_bitmap = ptr
         return bm
+
+    @property
+    def raw_pointer(self):
+        """
+        The address of the underlying `roaring_bitmap_t`, as a Python int.
+
+        Intended for FFI interop, e.g. passing the bitmap to another
+        native extension via CFFI or ctypes without a copy.
+
+        Caveats (the caller is responsible for all of these):
+
+        - The pointer is owned by this Python object. It is only valid
+          while the object is alive; the caller must not pass it to
+          `roaring_bitmap_free`.
+
+        - Mutating the bitmap through this pointer on a `FrozenBitMap`
+          is undefined behaviour: it silently invalidates the cached
+          hash and breaks set/dict semantics.
+        """
+        return <uintptr_t>self._c_bitmap
 
     @property
     def copy_on_write(self):

--- a/test.py
+++ b/test.py
@@ -13,6 +13,7 @@ import operator
 import unittest
 import functools
 import base64
+import ctypes
 from typing import TYPE_CHECKING
 from collections.abc import Set, Callable, Iterable, Iterator
 
@@ -1855,6 +1856,33 @@ class TestVersion:
     def test_version(self) -> None:
         self.assert_regex(r'\d+\.\d+\.\d+(?:\.dev\d+)?', pyroaring.__version__)
         self.assert_regex(r'v\d+\.\d+\.\d+', pyroaring.__croaring_version__)
+
+
+class TestFFI:
+    def test_ffi_get_ptr(self) -> None:
+        bm1 = BitMap()
+        bm2 = BitMap()
+
+        assert bm1.raw_pointer == bm1.raw_pointer
+        assert bm2.raw_pointer == bm2.raw_pointer
+        assert bm1.raw_pointer != bm2.raw_pointer
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="Symbols are not exported on Windows")
+    def test_ffi_cardinality(self) -> None:
+        bm = BitMap()
+        lib = ctypes.cdll.LoadLibrary(pyroaring.__file__)
+
+        raw_ptr = bm.raw_pointer
+        ffi_ptr = ctypes.c_void_p(raw_ptr)
+
+        if is_32_bits:
+            ffi_cardinality_fn = lib.roaring_bitmap_get_cardinality
+        else:
+            ffi_cardinality_fn = lib.roaring64_bitmap_get_cardinality
+
+        assert ffi_cardinality_fn(ffi_ptr) == 0
+        bm.add(42)
+        assert ffi_cardinality_fn(ffi_ptr) == 1
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This is useful for FFI.

I want to access the underlying C structure in another native extension through [CFFI](https://github.com/python-cffi/cffi/).

If this could be integrated, I would be grateful.